### PR TITLE
Feat/19 setup rsdata

### DIFF
--- a/backend/src/main/java/site/kkokkio/global/aspect/ResponseAspect.java
+++ b/backend/src/main/java/site/kkokkio/global/aspect/ResponseAspect.java
@@ -1,0 +1,48 @@
+package site.kkokkio.global.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.global.dto.RsData;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ResponseAspect {
+	private final HttpServletResponse response;
+
+	@Around("""
+		(
+		    within
+		    (
+		        @org.springframework.web.bind.annotation.RestController *
+		    )
+		    &&
+		    (
+		        @annotation(org.springframework.web.bind.annotation.GetMapping)
+		        ||
+		        @annotation(org.springframework.web.bind.annotation.PostMapping)
+		        ||
+		        @annotation(org.springframework.web.bind.annotation.PutMapping)
+		        ||
+		        @annotation(org.springframework.web.bind.annotation.DeleteMapping)
+		    )
+		)
+		||
+		@annotation(org.springframework.web.bind.annotation.ResponseBody)
+		""")
+	public Object responseAspect(ProceedingJoinPoint joinPoint) throws Throwable {
+		Object rst = joinPoint.proceed(); // 실제 수행 메서드
+
+		if (rst instanceof RsData rsData) {
+			int statusCode = rsData.getStatusCode();
+			response.setStatus(statusCode);
+		}
+
+		return rst; // json으로 변환되어 응답
+	}
+}

--- a/backend/src/main/java/site/kkokkio/global/aspect/ResponseAspect.java
+++ b/backend/src/main/java/site/kkokkio/global/aspect/ResponseAspect.java
@@ -36,13 +36,16 @@ public class ResponseAspect {
 		@annotation(org.springframework.web.bind.annotation.ResponseBody)
 		""")
 	public Object responseAspect(ProceedingJoinPoint joinPoint) throws Throwable {
-		Object rst = joinPoint.proceed(); // 실제 수행 메서드
 
+		// 실제 Controller 메서드(또는 @ResponseBody) 수행
+		Object rst = joinPoint.proceed();
+
+		// 돌려받은 객체가 RsData일 경우
 		if (rst instanceof RsData rsData) {
-			int statusCode = rsData.getStatusCode();
-			response.setStatus(statusCode);
+			int statusCode = rsData.getStatusCode();// RsData.code의 앞부분을 꺼내
+			response.setStatus(statusCode);// HttpServletResponse에 상태 코드로 설정
 		}
 
-		return rst; // json으로 변환되어 응답
+		return rst; // 원래 리턴 객체를 그대로 반환 -> Json으로 변환 후 응답
 	}
 }

--- a/backend/src/main/java/site/kkokkio/global/dto/Empty.java
+++ b/backend/src/main/java/site/kkokkio/global/dto/Empty.java
@@ -1,0 +1,4 @@
+package site.kkokkio.global.dto;
+
+public class Empty {
+}

--- a/backend/src/main/java/site/kkokkio/global/dto/RsData.java
+++ b/backend/src/main/java/site/kkokkio/global/dto/RsData.java
@@ -19,10 +19,12 @@ public class RsData<T> {
 	@NonNull
 	private T data;
 
-	public RsData(String code, String msg) {
-		this(code, msg, (T)new Empty());
+	// data 없이 code/message만 보내고 싶을 때ㅔ 빈 객체로 채우는 생성자
+	public RsData(String code, String message) {
+		this(code, message, (T)new Empty());
 	}
 
+	// getStatusCode()로 코드 앞부분을 잘라 HTTP 응답 상태로 사용
 	@JsonIgnore
 	public int getStatusCode() {
 		String statusCodeStr = code.split("-")[0];

--- a/backend/src/main/java/site/kkokkio/global/dto/RsData.java
+++ b/backend/src/main/java/site/kkokkio/global/dto/RsData.java
@@ -1,0 +1,32 @@
+package site.kkokkio.global.dto;
+
+import org.springframework.lang.NonNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RsData<T> {
+	@NonNull
+	private String code;
+	@NonNull
+	private String message;
+	@NonNull
+	private T data;
+
+	public RsData(String code, String msg) {
+		this(code, msg, (T)new Empty());
+	}
+
+	@JsonIgnore
+	public int getStatusCode() {
+		String statusCodeStr = code.split("-")[0];
+		return Integer.parseInt(statusCodeStr);
+	}
+
+}

--- a/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import site.kkokkio.global.dto.RsData;
@@ -31,6 +32,21 @@ public class GlobalExceptionHandler {
 				new RsData<>(
 					"400",
 					message
+				)
+			);
+	}
+
+	// 서비스 로직에서 발생한 커스텀 예외(ServiceException) 처리
+	@ResponseStatus // ResponseEntity.status()에 우선권이 있음
+	@ExceptionHandler(ServiceException.class)
+	public ResponseEntity<RsData<Void>> ServiceExceptionHandle(ServiceException ex) {
+
+		return ResponseEntity
+			.status(ex.getStatusCode())
+			.body(
+				new RsData<>(
+					ex.getCode(),
+					ex.getMessage()
 				)
 			);
 	}

--- a/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<RsData<Void>> ServiceExceptionHandle(ServiceException ex) {
 
 		return ResponseEntity
-			.status(ex.getStatusCode())
+			.status(ex.getStatusCode()) // ex.getStatusCode() → RsData에서 파싱된 HTTP 상태
 			.body(
 				new RsData<>(
 					ex.getCode(),

--- a/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package site.kkokkio.global.exception;
+
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import site.kkokkio.global.dto.RsData;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	// @Valid 검증 실패 시
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<RsData<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+		// 검증 오류 메시지들 한줄로 합치기
+		String message = e.getBindingResult().getFieldErrors()
+			.stream()
+			.map(fe -> fe.getField() + " : " + fe.getCode() + " : " + fe.getDefaultMessage())
+			.sorted()
+			.collect(Collectors.joining("\n"));
+
+		// 400 코드로 RsData 생성 후 BAD_REQUEST(400) 상태로 응답
+		return ResponseEntity
+			.status(HttpStatus.BAD_REQUEST)
+			.body(
+				new RsData<>(
+					"400",
+					message
+				)
+			);
+	}
+}

--- a/backend/src/main/java/site/kkokkio/global/exception/ServiceException.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/ServiceException.java
@@ -5,12 +5,13 @@ import site.kkokkio.global.dto.RsData;
 public class ServiceException extends RuntimeException {
 
 	private RsData<?> rsData;
-
+	
 	public ServiceException(String code, String message) {
 		super(message);
 		rsData = new RsData<>(code, message);
 	}
 
+	// GlobalExceptionHandler에서 꺼내 쓸 수 있도록, RsData의 코드·메시지·상태코드 반환 메서드 제공
 	public String getCode() {
 		return rsData.getCode();
 	}

--- a/backend/src/main/java/site/kkokkio/global/exception/ServiceException.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/ServiceException.java
@@ -1,0 +1,25 @@
+package site.kkokkio.global.exception;
+
+import site.kkokkio.global.dto.RsData;
+
+public class ServiceException extends RuntimeException {
+
+	private RsData<?> rsData;
+
+	public ServiceException(String code, String message) {
+		super(message);
+		rsData = new RsData<>(code, message);
+	}
+
+	public String getCode() {
+		return rsData.getCode();
+	}
+
+	public String getMessage() {
+		return rsData.getMessage();
+	}
+
+	public int getStatusCode() {
+		return rsData.getStatusCode();
+	}
+}


### PR DESCRIPTION
## 연관된 이슈

> #19 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- RsData<T> — 응답 데이터를 한 번에 묶어주는 포장지
- ResponseAspect — RsData에 담긴 코드를 HTTP 상태로 설정해 주는 AOP
- GlobalExceptionHandler — 공통 예외를 한 곳에서 잡아 일관된 에러 응답 생성
- ServiceException - 서비스(비즈니스) 레이어에서 “특정 상황에 HTTP 상태 코드와 메시지를 담아 예외를 던지고 싶을 때” 사용하는 커스텀 예외

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- RsData
   - 모든 REST 응답을 code(응답 코드) + messgage(설명 메시지) + data(실제 반환 객체) 형태로 감싸 줍니다.
   - JSON 직렬화 시 data가 null이면 아예 필드가 없어지도록(@JsonInclude.NON_NULL) 합니다.
   - getStatusCode()로 코드 앞부분을 잘라 HTTP 응답 상태로 쓸 수 있게 해 줍니다.
- ResponseAspect
   - @RestController의 매핑 메서드나 @ResponseBody가 붙은 메서드를 모두 가로채(@Around)서, 반환값이 RsData일 때 RsData.getStatusCode()를 읽어 HTTP 상태(Response Status)에 자동으로 반영합니다.
- GlobalExceptionHandler
두 가지 예외 처리
	1. MethodArgumentNotValidException
	- @Valid, @RequestBody 검증 실패 시 발생
	- 필드별 에러 메시지를 합쳐 RsData<Void>(빈 data)로 응답, 상태 400
	2. ServiceException
	- 비즈니스 로직에서 직접 던지는 커스텀 예외
	- 예외가 담고 있는 HTTP 상태·코드·메시지를 그대로 읽어서 응답
- ServiceException
   - 서비스에서 직관적으로 예외를 던질 수 있게 해준다.
   - RsData에 담긴 코드·메시지·상태 코드를 손쉽게 전달
   - GlobalExceptionHandler와 결합되어 일관된 에러 응답을 만들어 주는 역할
#### 목적
- 컨트롤러는 반환 객체(RsData) 에만 집중
- HTTP 상태 설정·에러 메시지 포맷·예외 처리를 공통 코드로 깔끔하게 분리

closes #19