### PR TITLE
Feat: 구글 트렌드 인기 키워드 조회 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // for googleTrend
+    implementation 'com.rometools:rome:1.18.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/GoogleTrendsController.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/GoogleTrendsController.java
@@ -1,0 +1,23 @@
+package site.kkokkio.domain.keyword.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.service.GoogleTrendsRssService;
+
+@RestController
+@RequestMapping("/api/v1/keywords")
+@RequiredArgsConstructor
+public class GoogleTrendsController {
+
+	private final GoogleTrendsRssService googleTrendsRssService;
+
+	@GetMapping("trending-keywords")
+	public List<String> getTrendingKeywordsApi() {
+		return googleTrendsRssService.getTrendingKeywordsFromRss();
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyController.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
-import site.kkokkio.domain.keyword.controller.dto.KeywordMetricHourlyResponse;
+import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyResponse;
 import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
 import site.kkokkio.global.dto.RsData;
 

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyController.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyController.java
@@ -1,0 +1,29 @@
+package site.kkokkio.domain.keyword.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.controller.dto.KeywordMetricHourlyResponse;
+import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
+import site.kkokkio.global.dto.RsData;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/keywords")
+public class KeywordMetricHourlyController {
+	private final KeywordMetricHourlyService keywordMetricHourlyService;
+
+	@GetMapping("/top")
+	public RsData<List<KeywordMetricHourlyResponse>> getHourlyMetrics() {
+		List<KeywordMetricHourlyResponse> responses = keywordMetricHourlyService.findHourlyMetrics();
+		return new RsData<>(
+			"200",
+			"실시간 키워드를 불러왔습니다.",
+			responses
+		);
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/dto/KeywordMetricHourlyResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/dto/KeywordMetricHourlyResponse.java
@@ -1,0 +1,17 @@
+package site.kkokkio.domain.keyword.controller.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.NonNull;
+import site.kkokkio.global.enums.Platform;
+
+public record KeywordMetricHourlyResponse(
+	@NonNull Long keywordId,
+	@NonNull String text,
+	@NonNull Platform platform,
+	@NonNull LocalDateTime bucketAt,
+	int volume,
+	int score
+	) {
+
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/dto/KeywordMetricHourlyResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/dto/KeywordMetricHourlyResponse.java
@@ -1,4 +1,4 @@
-package site.kkokkio.domain.keyword.controller.dto;
+package site.kkokkio.domain.keyword.dto;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/main/java/site/kkokkio/domain/keyword/entity/KeywordMetricHourlyId.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/entity/KeywordMetricHourlyId.java
@@ -8,12 +8,14 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.kkokkio.global.enums.Platform;
 
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @EqualsAndHashCode

--- a/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordMetricHourlyRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordMetricHourlyRepository.java
@@ -1,5 +1,8 @@
 package site.kkokkio.domain.keyword.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,5 +10,6 @@ import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
 
 @Repository
 public interface KeywordMetricHourlyRepository extends JpaRepository<KeywordMetricHourly, Long> {
-
+	List<KeywordMetricHourly> findById_BucketAtBetween(LocalDateTime start, LocalDateTime end);
+	List<KeywordMetricHourly> findTop10ByOrderByCreatedAtDesc();
 }

--- a/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordMetricHourlyRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordMetricHourlyRepository.java
@@ -1,0 +1,11 @@
+package site.kkokkio.domain.keyword.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
+
+@Repository
+public interface KeywordMetricHourlyRepository extends JpaRepository<KeywordMetricHourly, Long> {
+
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordRepository.java
@@ -1,0 +1,13 @@
+package site.kkokkio.domain.keyword.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import site.kkokkio.domain.keyword.entity.Keyword;
+
+@Repository
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+	Optional<Keyword> findKeywordByText(String text);
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/service/GoogleTrendsRssService.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/service/GoogleTrendsRssService.java
@@ -1,0 +1,93 @@
+package site.kkokkio.domain.keyword.service;
+
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.SyndFeedInput;
+import com.rometools.rome.io.XmlReader;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URL;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.entity.Keyword;
+import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
+import site.kkokkio.domain.keyword.entity.KeywordMetricHourlyId;
+import site.kkokkio.domain.keyword.repository.KeywordMetricHourlyRepository;
+import site.kkokkio.global.enums.Platform;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleTrendsRssService {
+
+	private final KeywordService keywordService;
+	private final KeywordMetricHourlyService keywordMetricHourlyService;
+	private static final String GOOGLE_TRENDS_RSS_URL = "https://trends.google.co.kr/trending/rss?geo=KR";
+
+	@Transactional
+	public List<String> getTrendingKeywordsFromRss() {
+		List<String> trendingKeywords = new ArrayList<>();
+		try {
+			URL feedUrl = new URL(GOOGLE_TRENDS_RSS_URL);
+			SyndFeedInput input = new SyndFeedInput();
+			SyndFeed feed = input.build(new XmlReader(feedUrl));
+
+			for (SyndEntry entry : feed.getEntries()) {
+				// Keyword 생성 또는 조회
+				Keyword keyword = keywordService.createKeyword(
+					Keyword.builder()
+						.text(entry.getTitle())
+						.build()
+				);
+
+				String approxTraffic = "";
+				List<org.jdom2.Element> foreignMarkups = entry.getForeignMarkup();
+				for (org.jdom2.Element element : foreignMarkups) {
+					if ("approx_traffic".equals(element.getName()) && "https://trends.google.com/trending/rss".equals(element.getNamespaceURI())) {
+						approxTraffic = element.getText();
+						break;
+					}
+				}
+
+				int volume = parseApproxTraffic(approxTraffic);
+
+				// KeywordMetricHourlyId 생성 및 Keyword 설정
+				KeywordMetricHourlyId id = KeywordMetricHourlyId.builder()
+					.keywordId(keyword.getId())
+					.bucketAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+					.platform(Platform.GOOGLE_TREND)
+					.build();
+
+				KeywordMetricHourly keywordMetricHourly = KeywordMetricHourly.builder()
+					.id(id) // 생성한 ID 설정
+					.keyword(keyword)
+					.volume(volume)
+					.score(volume)
+					.build();
+
+				keywordMetricHourlyService.createKeywordMetricHourly(keywordMetricHourly);
+
+				trendingKeywords.add(entry.getTitle());
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		return trendingKeywords;
+	}
+
+	private Integer parseApproxTraffic(String approxTraffic) {
+		if (approxTraffic.endsWith("+")) {
+			return Integer.parseInt(approxTraffic.substring(0, approxTraffic.length() - 1));
+		}
+		try {
+			return Integer.parseInt(approxTraffic);
+		} catch (NumberFormatException e) {
+			// 변환 실패 시 기본값 또는 에러 처리
+			return 0; // 또는 다른 적절한 기본값
+		}
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
@@ -1,11 +1,16 @@
 package site.kkokkio.domain.keyword.service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.controller.dto.KeywordMetricHourlyResponse;
 import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
 import site.kkokkio.domain.keyword.repository.KeywordMetricHourlyRepository;
+import site.kkokkio.global.exception.ServiceException;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +20,26 @@ public class KeywordMetricHourlyService {
 	@Transactional
 	public KeywordMetricHourly createKeywordMetricHourly(KeywordMetricHourly keywordMetricHourly) {
 		return keywordMetricHourlyRepository.save(keywordMetricHourly);
+	}
+
+	// 가장 최근의 인기 키워드 10개 조회
+	@Transactional(readOnly = true)
+	public List<KeywordMetricHourlyResponse> findHourlyMetrics() {
+		List<KeywordMetricHourly> metrics = keywordMetricHourlyRepository.findTop10ByOrderByCreatedAtDesc();
+		if(metrics == null || metrics.isEmpty()) {
+			throw new ServiceException("400", "키워드를 불러오지 못했습니다.");
+		}
+		List<KeywordMetricHourlyResponse> responses = new ArrayList<>();
+		for (KeywordMetricHourly metric : metrics) {
+			responses.add(new KeywordMetricHourlyResponse(
+				metric.getId().getKeywordId(),
+				metric.getKeyword().getText(),
+				metric.getId().getPlatform(),
+				metric.getId().getBucketAt(),
+				metric.getVolume(),
+				metric.getScore()
+			));
+		}
+		return responses;
 	}
 }

--- a/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
@@ -1,0 +1,19 @@
+package site.kkokkio.domain.keyword.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
+import site.kkokkio.domain.keyword.repository.KeywordMetricHourlyRepository;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordMetricHourlyService {
+	private final KeywordMetricHourlyRepository keywordMetricHourlyRepository;
+
+	@Transactional
+	public KeywordMetricHourly createKeywordMetricHourly(KeywordMetricHourly keywordMetricHourly) {
+		return keywordMetricHourlyRepository.save(keywordMetricHourly);
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import site.kkokkio.domain.keyword.controller.dto.KeywordMetricHourlyResponse;
+import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyResponse;
 import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
 import site.kkokkio.domain.keyword.repository.KeywordMetricHourlyRepository;
 import site.kkokkio.global.exception.ServiceException;

--- a/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordService.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordService.java
@@ -1,0 +1,20 @@
+package site.kkokkio.domain.keyword.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.entity.Keyword;
+import site.kkokkio.domain.keyword.repository.KeywordRepository;
+
+@Service
+@RequiredArgsConstructor
+public class KeywordService {
+	private final KeywordRepository keywordRepository;
+
+	@Transactional
+	public Keyword createKeyword(Keyword keyword) {
+		return keywordRepository.findKeywordByText(keyword.getText())
+			.orElseGet(() -> keywordRepository.save(keyword));
+	}
+}


### PR DESCRIPTION
## 연관된 이슈

> #27 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

![image](https://github.com/user-attachments/assets/6b8b64e9-c478-4bf8-9779-4bbc10725e7d)
구글 트렌드 RSS 파싱 후 테이블 저장 기능 + 최근 인기 키워드 10개 조회


## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 
GoogleTrendsController의 trending-keywords api의 경우 구글 트렌드 키워드 저장 Service의 실행을 위해 임시로 작성해둔 api입니다. 테스팅 외 실제 사용할 경우는 없고 서비스 실행은 Batch를 통해 이루어질 예정입니다.

키워드 10개 조회의 경우 구글 트렌드 실검 순으로 테이블에 저장되는걸 감안해서 keywords/top api가 불려지는 시점에서 테이블의 가장 최근 데이터 10개를 조회하는 방식으로 구현하였습니다.
