### PR TITLE
Feat/35 naver news open api

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,10 +41,6 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -67,8 +63,14 @@ dependencies {
     testImplementation 'org.springframework.batch:spring-batch-test'
 
     // test
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     runtimeOnly 'com.h2database:h2'
+    testImplementation 'io.projectreactor:reactor-test:3.6.5'
+    testImplementation 'org.mockito:mockito-core:4.6.1'
 
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,7 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -46,7 +48,6 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-
     // JWT
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
@@ -55,6 +56,12 @@ dependencies {
     // for googleTrend
     implementation 'com.rometools:rome:1.18.0'
 
+    // resilience4j
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+    implementation 'io.github.resilience4j:resilience4j-reactor:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // springBatch
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     testImplementation 'org.springframework.batch:spring-batch-test'
@@ -62,6 +69,7 @@ dependencies {
     // test
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     runtimeOnly 'com.h2database:h2'
+
 }
 
 tasks.named('test') {

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/backend/src/main/java/site/kkokkio/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/entity/Comment.java
@@ -44,9 +44,11 @@ public class Comment extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String body;
 
+	@Builder.Default
     @Column(name = "like_count", nullable = false)
     private int likeCount = 0;
 
+	@Builder.Default
     @Column(name = "is_hidden", nullable = false)
     private boolean hidden = false;
 

--- a/backend/src/main/java/site/kkokkio/domain/keyword/entity/KeywordMetricHourly.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/entity/KeywordMetricHourly.java
@@ -34,9 +34,11 @@ public class KeywordMetricHourly extends BaseTimeEntity {
     @JoinColumn(name = "keyword_id", nullable = false)
     private Keyword keyword;
 
+    @Builder.Default
     @Column(nullable = false)
     private int volume = 0;
 
+    @Builder.Default
     @Column(nullable = false)
     private int score = 0;
 }

--- a/backend/src/main/java/site/kkokkio/domain/member/entity/Member.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/entity/Member.java
@@ -47,10 +47,12 @@ public class Member extends BaseTimeEntity {
     @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
 
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private MemberRole role = MemberRole.USER;
 
+    @Builder.Default
 	@Column(name = "email_verified", nullable = false)
     private boolean emailVerified = false;
 

--- a/backend/src/main/java/site/kkokkio/domain/post/entity/Post.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/entity/Post.java
@@ -40,6 +40,7 @@ public class Post extends BaseTimeEntity {
     @Column(name = "bucket_at", nullable = false)
     private LocalDateTime bucketAt;
 
+	@Builder.Default
     @Column(name = "report_count", nullable = false)
     private int reportCount = 0;
 }

--- a/backend/src/main/java/site/kkokkio/domain/post/entity/PostMetricHourly.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/entity/PostMetricHourly.java
@@ -41,9 +41,11 @@ public class PostMetricHourly extends BaseTimeEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @Builder.Default
     @Column(name = "click_count", nullable = false)
     private int clickCount = 0;
 
+    @Builder.Default
     @Column(name = "like_count", nullable = false)
     private int likeCount = 0;
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/NewsDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/NewsDto.java
@@ -1,0 +1,27 @@
+package site.kkokkio.domain.source.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Value;
+import site.kkokkio.domain.source.entity.Source;
+
+@Value
+@Builder
+public class NewsDto {
+    String title;
+    String link;
+    String originalLink;
+    String description;
+    LocalDateTime pubDate;
+
+	public static NewsDto from(Source source) {
+		return NewsDto.builder()
+            .title(source.getTitle())
+            .link(source.getNormalizedUrl())
+            .originalLink(source.getNormalizedUrl())
+            .description(source.getDescription())
+            .pubDate(source.getPublishedAt())
+			.build();
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/NewsDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/NewsDto.java
@@ -3,25 +3,27 @@ package site.kkokkio.domain.source.dto;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
-import lombok.Value;
 import site.kkokkio.domain.source.entity.Source;
+import site.kkokkio.global.enums.Platform;
+import site.kkokkio.global.util.HashUtils;
 
-@Value
 @Builder
-public class NewsDto {
-    String title;
-    String link;
-    String originalLink;
-    String description;
-    LocalDateTime pubDate;
-
-	public static NewsDto from(Source source) {
-		return NewsDto.builder()
-            .title(source.getTitle())
-            .link(source.getNormalizedUrl())
-            .originalLink(source.getNormalizedUrl())
-            .description(source.getDescription())
-            .pubDate(source.getPublishedAt())
-			.build();
-	}
+public record NewsDto(
+    String title,
+    String link,
+    String originalLink,
+    String description,
+    LocalDateTime pubDate
+) {
+    public Source toEntity(Platform platform) {
+        return Source.builder()
+                     .fingerprint(HashUtils.sha256Hex(link))
+                     .normalizedUrl(link)
+                     .title(title)
+                     .description(description)
+                     .thumbnailUrl(null)
+                     .publishedAt(pubDate)
+                     .platform(platform)
+                     .build();
+    }
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/entity/Source.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/entity/Source.java
@@ -52,7 +52,6 @@ public class Source extends BaseTimeEntity {
     @Column(nullable = false)
     private Platform platform;
 
-
     /**
      * persist 직전에 URL을 해싱해 fingerprint를 자동 할당
      */

--- a/backend/src/main/java/site/kkokkio/domain/source/entity/Source.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/entity/Source.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.util.BaseTimeEntity;
+import site.kkokkio.global.util.HashUtils;
 
 /**
  * INDEX (platform, fetched_at)
@@ -49,4 +51,15 @@ public class Source extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Platform platform;
+
+
+    /**
+     * persist 직전에 URL을 해싱해 fingerprint를 자동 할당
+     */
+    @PrePersist
+    public void calculateFingerprint() {
+        if (this.fingerprint == null && this.normalizedUrl != null) {
+            this.fingerprint = HashUtils.sha256Hex(this.normalizedUrl);
+        }
+    }
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/entity/Source.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/entity/Source.java
@@ -37,6 +37,9 @@ public class Source extends BaseTimeEntity {
     @Column
     private String title;
 
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
     @Column(name = "thumbnail_url", columnDefinition = "TEXT")
     private String thumbnailUrl;
 

--- a/backend/src/main/java/site/kkokkio/domain/source/port/out/NewsApiPort.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/port/out/NewsApiPort.java
@@ -10,7 +10,7 @@ import site.kkokkio.domain.source.dto.NewsDto;
  */
 public interface NewsApiPort {
     /**
-     * fetchNews
+     * fetchNews (비동기)
      * @param keyword 검색어
      * @param display 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)
      * @param start 검색 시작 위치(기본값: 1, 최댓값: 1000)

--- a/backend/src/main/java/site/kkokkio/domain/source/port/out/NewsApiPort.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/port/out/NewsApiPort.java
@@ -1,0 +1,24 @@
+package site.kkokkio.domain.source.port.out;
+
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+import site.kkokkio.domain.source.dto.NewsDto;
+
+/**
+ * 외부 뉴스 검색 API 호출용 Port
+ */
+public interface NewsApiPort {
+    /**
+     * fetchNews
+     * @param keyword 검색어
+     * @param display 한 번에 표시할 검색 결과 개수(기본값: 10, 최댓값: 100)
+     * @param start 검색 시작 위치(기본값: 1, 최댓값: 1000)
+     * @param sort 검색 결과 정렬(sim: 정확도 내림차순 - 기본값, date: 날짜 내림차순)
+     * @return list of NewsDto
+     */
+    Mono<List<NewsDto>> fetchNews(String keyword,
+                            Integer display,
+                            Integer start,
+                            String sort);
+}

--- a/backend/src/main/java/site/kkokkio/domain/source/port/out/SourceNewsPort.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/port/out/SourceNewsPort.java
@@ -1,4 +1,0 @@
-package site.kkokkio.domain.source.port.out;
-
-public class SourceNewsPort {
-}

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
 import site.kkokkio.domain.source.entity.PostSource;
 import site.kkokkio.global.enums.Platform;
 

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/SourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/SourceRepository.java
@@ -1,11 +1,38 @@
 package site.kkokkio.domain.source.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import site.kkokkio.domain.source.entity.Source;
+import site.kkokkio.global.enums.Platform;
 
 @Repository
 public interface SourceRepository extends JpaRepository<Source, String> {
-
+	/**
+	 * TODO: source-keyword 조회가 많아질 경우 정규화를 깨고 SourceKeyword 테이블 설계 필요
+	 */
+    @Query("""
+        select s
+        from Source s
+		where s.platform = :platform
+		and exists (
+			select 1
+			from PostSource ps
+				join ps.post p
+				join PostKeyword pk on pk.post = p
+				join pk.keyword k
+			where ps.source = s
+			and k.text = :keyword
+		)
+		order by s.publishedAt desc
+		""")
+	List<Source> findLatest10ByPlatformAndKeyword(
+        @Param("platform") Platform platform,
+        @Param("keyword")  String   keyword,
+        Pageable pageable);
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
@@ -1,33 +1,46 @@
 package site.kkokkio.domain.source.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import site.kkokkio.domain.post.service.PostService;
+import site.kkokkio.domain.source.dto.NewsDto;
 import site.kkokkio.domain.source.dto.SourceDto;
 import site.kkokkio.domain.source.entity.PostSource;
+import site.kkokkio.domain.source.entity.Source;
+import site.kkokkio.domain.source.port.out.NewsApiPort;
 import site.kkokkio.domain.source.repository.PostSourceRepository;
+import site.kkokkio.domain.source.repository.SourceRepository;
 import site.kkokkio.global.enums.Platform;
+import site.kkokkio.global.util.HashUtils;
+import site.kkokkio.infra.common.exception.RetryableExternalApiException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SourceService {
 
 	private final PostSourceRepository postSourceRepository;
+    private final SourceRepository sourceRepository;
 	private final PostService postService;
+	private final NewsApiPort newsApi;
 
 	private static final int MAX_SOURCE_COUNT_PER_POST = 10;
+	private final Platform NEWS_PLATFORM = Platform.NAVER_NEWS;
+	private final Platform VIDEO_PLATFORM = Platform.YOUTUBE;
 
 	public List<SourceDto> getTop10NewsSourcesByPostId(Long postId) {
 		postService.getPostById(postId);
-		Platform newsPlatform = Platform.NAVER_NEWS;
 		PageRequest pageRequest = PageRequest.of(0, MAX_SOURCE_COUNT_PER_POST);
 		List<PostSource> postSources = postSourceRepository.findAllWithSourceByPostIdAndPlatform(
 			postId,
-			newsPlatform,
+			NEWS_PLATFORM,
 			pageRequest);
 		return postSources.stream()
 			.map(ps -> SourceDto.from(ps.getSource()))
@@ -36,14 +49,68 @@ public class SourceService {
 
 	public List<SourceDto> getTop10VideoSourcesByPostId(Long postId) {
 		postService.getPostById(postId);
-		Platform videoPlatform = Platform.YOUTUBE;
 		PageRequest pageRequest = PageRequest.of(0, MAX_SOURCE_COUNT_PER_POST);
 		List<PostSource> postSources = postSourceRepository.findAllWithSourceByPostIdAndPlatform(
 			postId,
-			videoPlatform,
+			VIDEO_PLATFORM,
 			pageRequest);
 		return postSources.stream()
 			.map(ps -> SourceDto.from(ps.getSource()))
 			.toList();
 	}
+
+	public void searchNews(String keyword) {
+		try {
+            List<NewsDto> newsList = fetchNewsBlocking(keyword);
+
+            if (newsList.isEmpty()) {
+                log.warn("Naver API 응답이 비어있음. keyword={}", keyword);
+                return;
+            }
+            saveSources(convertToSources(newsList));
+        } catch (RetryableExternalApiException retryEx) {
+            log.warn("외부 API 실패 → DB fallback. cause={}", retryEx.getMessage());
+            saveSources(fetchFallbackSources(keyword));
+        }
+    }
+
+    /** Naver News API 호출
+	 * null/empty 시 빈 리스트로 반환
+	 */
+    private List<NewsDto> fetchNewsBlocking(String keyword) {
+        return Optional.ofNullable(
+                   newsApi.fetchNews(keyword, MAX_SOURCE_COUNT_PER_POST, 1, "sim")
+                          .block()
+               )
+               .orElseGet(Collections::emptyList);
+    }
+
+    /** NewsDto → Source Mapping */
+    private List<Source> convertToSources(List<NewsDto> dtos) {
+        return dtos.stream()
+                   .map(dto -> Source.builder()
+                       .fingerprint(HashUtils.sha256Hex(dto.getLink()))
+                       .normalizedUrl(dto.getLink())
+                       .title(dto.getTitle())
+                       .description(dto.getDescription())
+                       .thumbnailUrl(null)
+                       .publishedAt(dto.getPubDate())
+                       .platform(NEWS_PLATFORM)
+                       .build()
+                   )
+                   .toList();
+    }
+
+    /** fallback용 DB 조회 */
+    private List<Source> fetchFallbackSources(String keyword) {
+		PageRequest pageRequest = PageRequest.of(0, MAX_SOURCE_COUNT_PER_POST);
+        return sourceRepository
+                .findLatest10ByPlatformAndKeyword(NEWS_PLATFORM, keyword, pageRequest);
+    }
+
+    private void saveSources(List<Source> sources) {
+        if (!sources.isEmpty()) {
+            sourceRepository.saveAll(sources);
+        }
+    }
 }

--- a/backend/src/main/java/site/kkokkio/global/config/WebClientConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/WebClientConfig.java
@@ -1,0 +1,21 @@
+package site.kkokkio.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient naverWebClient(
+            @Value("${naver.base-url}") String baseUrl) {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+}

--- a/backend/src/main/java/site/kkokkio/global/exception/ServiceException.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/ServiceException.java
@@ -4,7 +4,7 @@ import site.kkokkio.global.dto.RsData;
 
 public class ServiceException extends RuntimeException {
 
-	private RsData<?> rsData;
+	private final RsData<?> rsData;
 	
 	public ServiceException(String code, String message) {
 		super(message);

--- a/backend/src/main/java/site/kkokkio/global/util/HashUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/HashUtils.java
@@ -1,0 +1,32 @@
+package site.kkokkio.global.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Hash 관련 유틸리티 클래스
+@Slf4j
+@Component
+public class HashUtils {
+    public static String sha256Hex(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 해싱 실패", e);
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder hex = new StringBuilder(2 * bytes.length);
+        for (byte b : bytes) {
+            hex.append(String.format("%02x", b));
+        }
+        return hex.toString();
+    }
+}

--- a/backend/src/main/java/site/kkokkio/infra/common/exception/ClientBadRequestException.java
+++ b/backend/src/main/java/site/kkokkio/infra/common/exception/ClientBadRequestException.java
@@ -1,0 +1,12 @@
+package site.kkokkio.infra.common.exception;
+
+import site.kkokkio.global.exception.ServiceException;
+
+/**
+ * 잘못된 입력(4xx) → 즉시 실패
+ */
+public class ClientBadRequestException extends ServiceException {
+    public ClientBadRequestException(int status, String msg){
+        super(String.valueOf(status), msg);
+    }
+}

--- a/backend/src/main/java/site/kkokkio/infra/common/exception/ExternalApiErrorUtil.java
+++ b/backend/src/main/java/site/kkokkio/infra/common/exception/ExternalApiErrorUtil.java
@@ -1,0 +1,28 @@
+package site.kkokkio.infra.common.exception;
+
+import org.springframework.http.HttpStatusCode;
+
+import lombok.NoArgsConstructor;
+import site.kkokkio.global.exception.ServiceException;
+
+@NoArgsConstructor
+public final class ExternalApiErrorUtil {
+
+    public static ServiceException of(HttpStatusCode status,
+                                      String vendorCode,   // null 가능
+                                      String vendorMsg) {
+
+        int statusCode = status.value();
+
+        String msg = vendorMsg != null && !vendorMsg.isBlank()
+                   ? vendorMsg
+                   : status.toString();
+
+        if (vendorCode != null && !vendorCode.isBlank()) {
+            msg = String.format("[%s] %s", vendorCode, msg);
+        }
+        return (statusCode == 429 || statusCode >= 500)
+           ? new RetryableExternalApiException(statusCode, msg)
+           : new ClientBadRequestException(statusCode, msg);
+    }
+}

--- a/backend/src/main/java/site/kkokkio/infra/common/exception/RetryableExternalApiException.java
+++ b/backend/src/main/java/site/kkokkio/infra/common/exception/RetryableExternalApiException.java
@@ -1,0 +1,12 @@
+package site.kkokkio.infra.common.exception;
+
+import site.kkokkio.global.exception.ServiceException;
+
+/**
+ * 429 또는 5xx → 재시도·서킷브레이커 대상
+ */
+public class RetryableExternalApiException extends ServiceException {
+    public RetryableExternalApiException(int status, String msg){
+        super(String.valueOf(status), msg);
+    }
+}

--- a/backend/src/main/java/site/kkokkio/infra/naver/news/NaverErrorResponse.java
+++ b/backend/src/main/java/site/kkokkio/infra/naver/news/NaverErrorResponse.java
@@ -1,0 +1,17 @@
+package site.kkokkio.infra.naver.news;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverErrorResponse {
+
+    @JsonProperty("errorCode")
+    private String code;
+
+    @JsonProperty("errorMessage")
+    private String message;
+}

--- a/backend/src/main/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapter.java
+++ b/backend/src/main/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapter.java
@@ -1,0 +1,108 @@
+package site.kkokkio.infra.naver.news;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import site.kkokkio.domain.source.dto.NewsDto;
+import site.kkokkio.domain.source.port.out.NewsApiPort;
+import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.infra.common.exception.ExternalApiErrorUtil;
+import site.kkokkio.infra.common.exception.RetryableExternalApiException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverNewsApiAdapter implements NewsApiPort {
+
+    @Qualifier("naverWebClient")
+	private final WebClient naverWebClient;
+
+	@Value("${naver.client-id}")
+	private String NAVER_CLIENT_ID;
+
+    @Value("${naver.client-secret}")
+    private String NAVER_CLIENT_SECRET;
+
+    @Value("${naver.search.news-path}")
+    private String NAVER_SEARCH_NEWS_PATH;
+
+    @Retry(name = "NAVER_NEWS_RETRY")
+    @RateLimiter(name = "NAVER_NEWS_RATE_LIMITER")
+    @CircuitBreaker(name = "NAVER_NEWS_CIRCUIT_BREAKER", fallbackMethod = "openCircuitFallback")
+	@Override
+	public Mono<List<NewsDto>> fetchNews(String keyword, Integer display, Integer start, String sort) {
+
+        return naverWebClient.get()
+            .uri(uri -> buildUri(uri, keyword, display, start, sort))
+            .header("X-Naver-Client-Id", NAVER_CLIENT_ID)
+            .header("X-Naver-Client-Secret", NAVER_CLIENT_SECRET)
+            .retrieve()
+			.onStatus(HttpStatusCode::isError, this::mapError)
+            .bodyToMono(NaverNewsSearchResponse.class)
+			// 서킷 오픈 시 CallNotPermittedException → RetryableExternalApiException으로 변환
+			.onErrorMap(CallNotPermittedException.class,
+				ex -> new RetryableExternalApiException(503, ex.getMessage()))
+			// 5xx·429 에러(ExternalApiErrorUtil)가 이미 RetryableExternalApiException으로 Mapping됨
+            .map(this::toNewsDtos);
+	}
+
+	private URI buildUri(UriBuilder uriBuilder, String query, Integer display, Integer start, String sort) {
+		String encoded = encode(query);
+		UriBuilder ub = uriBuilder.path(NAVER_SEARCH_NEWS_PATH).queryParam("query", encoded);
+		if (display != null) {
+			ub.queryParam("display", display);
+		}
+		if (start != null) {
+			ub.queryParam("start", start);
+		}
+		if (sort != null) {
+			ub.queryParam("sort", sort);
+		}
+		return ub.build();
+	}
+
+    private Mono<? extends Throwable> mapError(ClientResponse response) {
+        return response.bodyToMono(NaverErrorResponse.class)
+                   .defaultIfEmpty(new NaverErrorResponse())
+                   .flatMap(err -> Mono.error(
+                       ExternalApiErrorUtil.of(response.statusCode(), err.getCode(), err.getMessage())
+                   ));
+    }
+
+    private List<NewsDto> toNewsDtos(NaverNewsSearchResponse response) {
+        if (response == null || response.getItems() == null) {
+            throw new ServiceException("502", "Empty response from Naver News API");
+        }
+        return response.getItems().stream()
+                       .map(item -> NewsDto.builder()
+                                           .title(item.getTitle())
+                                           .link(item.getLink())
+                                           .originalLink(item.getOriginalLink())
+                                           .description(item.getDescription())
+                                           .pubDate(item.getPubDate().toLocalDateTime())
+                                           .build())
+                       .toList();
+    }
+
+	private static String encode(String text) {
+        return URLEncoder.encode(text, StandardCharsets.UTF_8);
+	}
+
+}

--- a/backend/src/main/java/site/kkokkio/infra/naver/news/NaverNewsSearchResponse.java
+++ b/backend/src/main/java/site/kkokkio/infra/naver/news/NaverNewsSearchResponse.java
@@ -1,0 +1,32 @@
+package site.kkokkio.infra.naver.news;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverNewsSearchResponse {
+
+    private List<NaverNewsSearchItem> items;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class NaverNewsSearchItem {
+        private String title;
+        private String link;
+
+        @JsonProperty("originallink")
+        private String originalLink;
+
+        private String description;
+
+        @JsonFormat(pattern = "EEE, dd MMM yyyy HH:mm:ss Z", locale = "en")
+        private OffsetDateTime pubDate;
+    }
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -9,3 +9,48 @@ spring:
     database: h2
     hibernate:
       ddl-auto: create-drop # 테스트 시작 시 테이블 생성, 종료 시 삭제
+
+  main:
+    allow-bean-definition-overriding: true
+
+resilience4j:
+  retry:
+    configs:
+      default:
+        max-attempts: 2
+        wait-duration: 0ms
+        enable-exponential-backoff: false
+        retry-exceptions:
+          - site.kkokkio.infra.common.exception.RetryableExternalApiException
+        ignore-exceptions:
+          - site.kkokkio.infra.common.exception.ClientBadRequestException
+    instances:
+      NAVER_NEWS_RETRY:
+        base-config: default
+  circuitbreaker:
+    configs:
+      default:
+        sliding-window-type: COUNT_BASED
+        sliding-window-size: 2
+        failure-rate-threshold: 50
+        record-exceptions:
+          - site.kkokkio.infra.common.exception.RetryableExternalApiException
+        ignore-exceptions:
+          - site.kkokkio.infra.common.exception.ClientBadRequestException
+    instances:
+      NAVER_NEWS_CIRCUIT_BREAKER:
+        base-config: default
+  ratelimiter:
+    configs:
+      default:
+        limit-for-period: 2
+        limit-refresh-period: 1s
+        timeout-duration: 0
+    instances:
+      NAVER_NEWS_RATE_LIMITER:
+        base-config: default
+
+management:
+  observations:
+    enable:
+      http.client.requests: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -49,8 +49,73 @@ spring:
     serialization:
       FAIL_ON_EMPTY_BEANS: false # 빈 객체도 직렬화가 가능하도록 설정 (Empty)
 
+resilience4j:
+  retry:
+    configs:
+      default:
+        max-attempts: 3 # 최대 재시도 수
+        wait-duration: 1s # 재시도 할 때마다 기다리는 고정시간
+        enable-exponential-backoff: true
+        exponential-backoff-multiplier: 2
+        retry-exceptions:
+          - site.kkokkio.infra.common.exception.RetryableExternalApiException
+        ignore-exceptions:
+          - site.kkokkio.infra.common.exception.ClientBadRequestException
+    instances:
+      NAVER_NEWS_RETRY:
+        base-config: default
+  circuitbreaker:
+    configs:
+      default:
+        sliding-window-type: COUNT_BASED # COUNT_BASED: sliding-window-size 만큼의 마지막 call들이 기록되고 집계된다
+        sliding-window-size: 10 # CLOSED 상태에서 집계되는 슬라이딩 윈도우 크기
+        failure-rate-threshold: 50 # 실패 비율 임계치를 백분율로 설정
+        wait-duration-in-open-state: 20s # OPEN에서 HALF_OPEN 상태로 전환하기 전 기다리는 시간
+        automatic-transition-from-open-to-half-open-enabled: true
+        register-health-indicator: true
+        record-exceptions:
+          - site.kkokkio.infra.common.exception.RetryableExternalApiException
+        ignore-exceptions:
+          - site.kkokkio.infra.common.exception.ClientBadRequestException
+    instances:
+      NAVER_NEWS_CIRCUIT_BREAKER:
+        base-config: default
+  ratelimiter:
+    configs:
+      default:
+        limit-for-period: 8 # 초당 8 건
+        limit-refresh-period: 1s
+        timeout-duration: 0 # 대기 없이 즉시 실패
+    instances:
+      NAVER_NEWS_RATE_LIMITER:
+        base-config: default
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+      base-path: /api/actuator
+  endpoint:
+    health:
+      probes:
+        enabled: true # readiness/liveness 포함
+      show-details: always
+  health:
+    circuitbreakers:
+      enabled: true
+  server:
+    port: 8081
+
 google:
   trends:
     rss:
       url: ${GOOGLE_TRENDS_RSS_URL}
       namespace: ${NAMESPACE_URL}
+
+naver:
+  base-url: ${NAVER_BASE_URL:https://openapi.naver.com}
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+  search:
+    news-path: ${NAVER_SEARCH_NEWS_PATH:/v1/search/news.json}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       enabled: false
 
   profiles:
-    active: ${SPRING_ACTIVE_PROFILES:dev}
+    active: ${SPRING_ACTIVE_PROFILES:test}
 
   data:
     redis:
@@ -42,8 +42,8 @@ spring:
     locations: classpath:db/migration # migration 스크립트 위치
 
   jwt:
-    secret-key: ${JWT_SECRET_KEY}
-    expiration: ${JWT_EXPIRATION}
+    secret-key: ${JWT_SECRET_KEY:test123}
+    expiration: ${JWT_EXPIRATION:600000}
 
   jackson:
     serialization:
@@ -110,12 +110,12 @@ management:
 google:
   trends:
     rss:
-      url: ${GOOGLE_TRENDS_RSS_URL}
-      namespace: ${NAMESPACE_URL}
+      url: ${GOOGLE_TRENDS_RSS_URL:https://trends.google.co.kr/trending/rss?geo=KR}
+      namespace: ${NAMESPACE_URL:https://trends.google.com/trending/rss}
 
 naver:
   base-url: ${NAVER_BASE_URL:https://openapi.naver.com}
-  client-id: ${NAVER_CLIENT_ID}
-  client-secret: ${NAVER_CLIENT_SECRET}
+  client-id: ${NAVER_CLIENT_ID:test-id}
+  client-secret: ${NAVER_CLIENT_SECRET:test-secret}
   search:
     news-path: ${NAVER_SEARCH_NEWS_PATH:/v1/search/news.json}

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -91,6 +91,7 @@ CREATE TABLE source (
   fingerprint VARCHAR(64) PRIMARY KEY,
   normalized_url VARCHAR(500) NOT NULL,
   title VARCHAR(255),
+  description TEXT,
   thumbnail_url TEXT,
   published_at DATETIME NOT NULL,
   platform VARCHAR(30) NOT NULL,

--- a/backend/src/test/java/site/kkokkio/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/post/service/PostServiceTest.java
@@ -120,8 +120,8 @@ public class PostServiceTest {
 			.build();
 
 		given(keywordMetricHourlyRepository.findTop10ById_BucketAtOrderByScoreDesc(any())).willReturn(List.of(metric));
-		given(keywordPostHourlyRepository.findById_KeywordIdAndId_BucketAt(100L, now)).willReturn(
-			Optional.of(keywordPostHourly));
+		given(keywordPostHourlyRepository.findById_KeywordIdAndId_BucketAt(eq(100L), any(LocalDateTime.class)))
+			.willReturn(Optional.of(keywordPostHourly));
 
 		// when
 		List<PostDto> result = postService.getTopPostsWithKeyword();

--- a/backend/src/test/java/site/kkokkio/domain/source/repository/SourceRepositoryTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/repository/SourceRepositoryTest.java
@@ -1,0 +1,97 @@
+package site.kkokkio.domain.source.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import site.kkokkio.domain.keyword.entity.Keyword;
+import site.kkokkio.domain.keyword.repository.KeywordRepository;
+import site.kkokkio.domain.post.entity.Post;
+import site.kkokkio.domain.post.entity.PostKeyword;
+import site.kkokkio.domain.post.repository.PostKeywordRepository;
+import site.kkokkio.domain.post.repository.PostRepository;
+import site.kkokkio.domain.source.entity.PostSource;
+import site.kkokkio.domain.source.entity.Source;
+import site.kkokkio.global.enums.Platform;
+
+@SpringBootTest
+@Transactional
+class SourceRepositoryTest {
+
+
+    @Autowired
+	private SourceRepository       sourceRepo;
+    @Autowired private PostRepository postRepo;
+    @Autowired private KeywordRepository keywordRepo;
+    @Autowired private PostKeywordRepository postKeywordRepo;
+    @Autowired private PostSourceRepository   postSourceRepo;
+
+	@Test
+	@DisplayName("플랫폼과 키워드 필터링 Query 검증 - 성공")
+	void findLatest10ByPlatformAndKeyword() {
+        // given
+        Keyword kw = keywordRepo.save(Keyword.builder().text("test").build());
+        Post post = postRepo.save(Post.builder()
+			.title("Test Post")
+			.bucketAt(LocalDateTime.now())
+			.summary("summary")
+			.build());
+        postKeywordRepo.save(PostKeyword.builder().post(post).keyword(kw).build());
+
+        Source oldest  = sourceRepo.save(
+            Source.builder()
+                  .normalizedUrl("url1")
+                  .thumbnailUrl(null)
+                  .title("old")
+                  .description("")
+                  .publishedAt(LocalDateTime.now().minusDays(3))
+                  .platform(Platform.NAVER_NEWS)
+                  .build()
+        );
+        Source newest   = sourceRepo.save(
+            Source.builder()
+                  .normalizedUrl("url3")
+                  .thumbnailUrl(null)
+                  .title("new")
+                  .description("")
+                  .publishedAt(LocalDateTime.now().minusDays(1))
+                  .platform(Platform.NAVER_NEWS)
+                  .build()
+        );
+        Source middle  = sourceRepo.save(
+            Source.builder()
+                  .normalizedUrl("url2")
+                  .thumbnailUrl(null)
+                  .title("mid")
+                  .description("")
+                  .publishedAt(LocalDateTime.now().minusDays(2))
+                  .platform(Platform.NAVER_NEWS)
+                  .build()
+        );
+
+        postSourceRepo.save(PostSource.builder().post(post).source(oldest).build());
+        postSourceRepo.save(PostSource.builder().post(post).source(middle).build());
+        postSourceRepo.save(PostSource.builder().post(post).source(newest).build());
+
+        // when
+        List<Source> results = sourceRepo.findLatest10ByPlatformAndKeyword(
+            Platform.NAVER_NEWS,
+            "test",
+            PageRequest.of(0, 10)
+        );
+
+        //--- then
+        assertThat(results)
+            .hasSize(3)
+            .extracting(Source::getNormalizedUrl)
+            .containsExactly("url3", "url2", "url1");
+    }
+}

--- a/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterTest.java
+++ b/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterTest.java
@@ -1,0 +1,198 @@
+package site.kkokkio.infra.naver.news;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.retry.RetryRegistry;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import site.kkokkio.infra.common.exception.RetryableExternalApiException;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class NaverNewsApiAdapterTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        ExchangeFunction exchangeFunction() {
+            return Mockito.mock(ExchangeFunction.class);
+        }
+
+        @Bean
+        @Qualifier("naverWebClient")
+        WebClient naverWebClient(ExchangeFunction ef) {
+            return WebClient.builder()
+                            .exchangeFunction(ef)
+                            .build();
+        }
+    }
+
+    @Autowired
+    private NaverNewsApiAdapter adapter;
+
+    @Autowired
+    private ExchangeFunction exchangeFunction;
+
+    @Autowired
+    private CircuitBreakerRegistry cbRegistry;
+
+    @Autowired
+    private RetryRegistry retryRegistry;
+
+    @Autowired
+    private RateLimiterRegistry rlRegistry;
+
+    private ClientResponse buildResponse(String json, HttpStatus status) {
+        return ClientResponse.create(status, ExchangeStrategies.withDefaults())
+                             .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                             .body(json)
+                             .build();
+    }
+
+    @Test
+    @DisplayName("Naver News 검색 API - 성공")
+    void fetchNews_success() {
+        // given
+        String successJson = """
+            {
+              "items":[
+                {
+                  "title":"t",
+                  "link":"l",
+                  "originallink":"o",
+                  "description":"d",
+                  "pubDate":"Wed, 24 Jul 2024 14:34:00 +0900"
+                }
+              ]
+            }
+            """;
+        when(exchangeFunction.exchange(any()))
+            .thenReturn(Mono.just(buildResponse(successJson, HttpStatus.OK)));
+
+        // when
+        var result = adapter.fetchNews("키워드", 10, 1, "sim");
+
+        // then
+        StepVerifier.create(result)
+                    .assertNext(list -> {
+                        assertThat(list).hasSize(1);
+                        assertThat(list.getFirst().getTitle()).isEqualTo("t");
+                    })
+                    .verifyComplete();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    @DisplayName("Naver News 검색 API - retry 확인")
+    void fetchNews_retry() {
+        // given
+        String errorJson = "{\"errorCode\":\"E\",\"errorMessage\":\"err\"}";
+        String successJson = """
+            {
+              "items":[
+                {
+                  "title":"s",
+                  "link":"l",
+                  "originallink":"o",
+                  "description":"d",
+                  "pubDate":"Wed, 24 Jul 2024 14:34:00 +0900"
+                }
+              ]
+            }
+            """;
+        when(exchangeFunction.exchange(any()))
+            .thenReturn(
+                Mono.just(buildResponse(errorJson,   HttpStatus.SERVICE_UNAVAILABLE)),
+                Mono.just(buildResponse(successJson, HttpStatus.OK))
+            );
+
+        // when
+        var result = adapter.fetchNews("키워드", 10, 1, "sim");
+
+        // then
+        StepVerifier.create(result)
+                    .assertNext(list -> {
+                        assertThat(list).hasSize(1);
+                        assertThat(list.getFirst().getTitle()).isEqualTo("s");
+                    })
+                    .verifyComplete();
+
+        // 2회 호출되었는지 검증
+        verify(exchangeFunction, times(2)).exchange(any());
+    }
+
+    @Test
+    @DisplayName("Naver News 검색 API - circuitBreaker 확인")
+    void fetchNews_circuitBreaker() {
+        // given
+        String errorJson = "{\"errorCode\":\"E\",\"errorMessage\":\"err\"}";
+        when(exchangeFunction.exchange(any()))
+            .thenReturn(Mono.just(buildResponse(errorJson, HttpStatus.SERVICE_UNAVAILABLE)));
+
+        // when: 첫 호출 (2회 retry 후 실패 -> RetryableExternalApiException)
+        StepVerifier.create(adapter.fetchNews("k", 10, 1, "sim"))
+                    .expectError(RetryableExternalApiException.class)
+                    .verify();
+
+        // then: 회로 열린 상태 확인
+        CircuitBreaker cb = cbRegistry.circuitBreaker("NAVER_NEWS_CIRCUIT_BREAKER");
+        assertThat(cb.getState()).isEqualTo(CircuitBreaker.State.OPEN);
+
+        // when: 두 번째 호출 → CallNotPermittedException
+        StepVerifier.create(adapter.fetchNews("k", 10, 1, "sim"))
+                    .expectError(CallNotPermittedException.class)
+                    .verify();
+
+        // then: 호출 2회만 발생
+        verify(exchangeFunction, times(2)).exchange(any());
+    }
+
+    @Test
+    @DisplayName("Naver News 검색 API - rateLimiter 확인")
+    void fetchNews_rateLimiter() {
+        // given
+        String emptyJson = "{\"items\":[]}";
+        when(exchangeFunction.exchange(any()))
+            .thenReturn(Mono.just(buildResponse(emptyJson, HttpStatus.OK)));
+
+        // when & then: 두 번 정상 호출
+        StepVerifier.create(adapter.fetchNews("k",10,1,"sim"))
+                    .expectNext(Collections.emptyList())
+                    .verifyComplete();
+        StepVerifier.create(adapter.fetchNews("k",10,1,"sim"))
+                    .expectNext(Collections.emptyList())
+                    .verifyComplete();
+
+        // when & then: 세 번째 호출 → RateLimiter 초과
+        StepVerifier.create(adapter.fetchNews("k",10,1,"sim"))
+                    .expectError(io.github.resilience4j.ratelimiter.RequestNotPermitted.class)
+                    .verify();
+    }
+}

--- a/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterTest.java
+++ b/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterTest.java
@@ -103,7 +103,7 @@ class NaverNewsApiAdapterTest {
         StepVerifier.create(result)
                     .assertNext(list -> {
                         assertThat(list).hasSize(1);
-                        assertThat(list.getFirst().getTitle()).isEqualTo("t");
+                        assertThat(list.getFirst().title()).isEqualTo("t");
                     })
                     .verifyComplete();
     }
@@ -140,7 +140,7 @@ class NaverNewsApiAdapterTest {
         StepVerifier.create(result)
                     .assertNext(list -> {
                         assertThat(list).hasSize(1);
-                        assertThat(list.getFirst().getTitle()).isEqualTo("s");
+                        assertThat(list.getFirst().title()).isEqualTo("s");
                     })
                     .verifyComplete();
 


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #35 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- Naver 뉴스 Open API를 호출해 도메인으로 매핑하고, 장애 시 DB Fallback을 적용하는 기능을 추가했습니다.
- Resilience4j의 Retry, CircuitBreaker, RateLimiter 애노테이션을 활용해 외부 호출 안정성을 확보했습니다.
- 에러 매핑 유틸과 예외 클래스를 분리해 Naver 뉴스의 4xx/5xx 응답을 케이스별로 명확히 처리하도록 개선했습니다.
- Retry, CircuitBreaker, RateLimiter 및 Fallback 까지 테스트 코드로 동작 확인 완료했습니다.
- 이후 스케줄러 설정을 진행할 예정입니다.

## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
- 이후 스케줄러 설정할 때 운영 환경이 아니라면 호출 제한이 있는 외부 API는 가짜 데이터를 반환하게 설정하려고 하는데 괜찮을지 의견 나누고 싶습니다..!

closes #35