### PR TITLE
Feat/25 set popular keyword for take youtube and naver news content

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
@@ -1,24 +1,23 @@
 package site.kkokkio.domain.source.controller;
 
-import java.util.List;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.source.controller.dto.SourceListResponse;
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
-import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.dto.RsData;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -60,7 +59,7 @@ public class SourceControllerV1 {
             @ParameterObject @PageableDefault(
                     size = 5,
                     sort = "score",
-                    direction = org.springframework.data.domain.Sort.Direction.DESC
+                    direction = Sort.Direction.DESC
             ) Pageable pageable
     ) {
         TopSourceListResponse topYoutubeSources = sourceService.getTopYoutubeSources(pageable);
@@ -81,7 +80,7 @@ public class SourceControllerV1 {
             @ParameterObject @PageableDefault(
                     size = 5,
                     sort = "score",
-                    direction = org.springframework.data.domain.Sort.Direction.DESC
+                    direction = Sort.Direction.DESC
             ) Pageable pageable
     ) {
         TopSourceListResponse topNewsSources = sourceService.getTopNaverNewsSources(pageable);

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
@@ -2,6 +2,9 @@ package site.kkokkio.domain.source.controller;
 
 import java.util.List;
 
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,7 +14,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.source.controller.dto.SourceListResponse;
+import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.dto.RsData;
 
@@ -20,29 +25,71 @@ import site.kkokkio.global.dto.RsData;
 @RequiredArgsConstructor
 @Tag(name = "Source API V1", description = "출처 관련 API 엔드포인트 V1")
 public class SourceControllerV1 {
-	private final SourceService sourceService;
+    private final SourceService sourceService;
 
-	@Operation(summary = "포스트의 출처 뉴스 Top 10 조회")
-	@GetMapping("/posts/{postId}/news")
-	public RsData<SourceListResponse> getNewsSourceList(@PathVariable("postId") Long postId) {
-		List<SourceDto> sources = sourceService.getTop10NewsSourcesByPostId(postId);
-		SourceListResponse sourceListResponse = SourceListResponse.from(sources);
-		return new RsData<>(
-			"200",
-			"성공적으로 조회되었습니다.",
-			sourceListResponse
-		);
-	}
+    @Operation(summary = "포스트의 출처 뉴스 Top 10 조회")
+    @GetMapping("/posts/{postId}/news")
+    public RsData<SourceListResponse> getNewsSourceList(@PathVariable("postId") Long postId) {
+        List<SourceDto> sources = sourceService.getTop10NewsSourcesByPostId(postId);
+        SourceListResponse sourceListResponse = SourceListResponse.from(sources);
+        return new RsData<>(
+                "200",
+                "성공적으로 조회되었습니다.",
+                sourceListResponse
+        );
+    }
 
-	@Operation(summary = "포스트의 출처 영상 Top 10 조회")
-	@GetMapping("/posts/{postId}/videos")
-	public RsData<SourceListResponse> getVideoSourceList(@PathVariable("postId") Long postId) {
-		List<SourceDto> sources = sourceService.getTop10VideoSourcesByPostId(postId);
-		SourceListResponse sourceListResponse = SourceListResponse.from(sources);
-		return new RsData<>(
-			"200",
-			"성공적으로 조회되었습니다.",
-			sourceListResponse
-		);
-	}
+    @Operation(summary = "포스트의 출처 영상 Top 10 조회")
+    @GetMapping("/posts/{postId}/videos")
+    public RsData<SourceListResponse> getVideoSourceList(@PathVariable("postId") Long postId) {
+        List<SourceDto> sources = sourceService.getTop10VideoSourcesByPostId(postId);
+        SourceListResponse sourceListResponse = SourceListResponse.from(sources);
+        return new RsData<>(
+                "200",
+                "성공적으로 조회되었습니다.",
+                sourceListResponse
+        );
+    }
+
+    @Operation(
+            summary = "실시간 인기 유튜브 비디오 목록 조회 (페이지네이션)",
+            description = "키워드를 통해 YouTube Data API를 호출하여 현재 한국에서 인기 있는 YouTube 비디오 목록을 가져옵니다."
+    )
+    @GetMapping("/videos/top")
+    public RsData<TopSourceListResponse> getTopYoutubeSources(
+            @ParameterObject @PageableDefault(
+                    size = 5,
+                    sort = "score",
+                    direction = org.springframework.data.domain.Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+        TopSourceListResponse topYoutubeSources = sourceService.getTopYoutubeSources(pageable);
+
+        return new RsData<>(
+                "200",
+                "정상적으로 호출되었습니다.",
+                topYoutubeSources
+        );
+    }
+
+    @Operation(
+            summary = "실시간 인기 네이버 뉴스 목록 조회 (페이지네이션)",
+            description = "키워드를 통해 네이버 뉴스 API를 호출하여 현재 한국에서 인기 있는 네이버 뉴스 목록을 가져옵니다."
+    )
+    @GetMapping("/news/top")
+    public RsData<TopSourceListResponse> getTopNaverNewsSources(
+            @ParameterObject @PageableDefault(
+                    size = 5,
+                    sort = "score",
+                    direction = org.springframework.data.domain.Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+        TopSourceListResponse topNewsSources = sourceService.getTopNaverNewsSources(pageable);
+
+        return new RsData<>(
+                "200",
+                "정상적으로 호출되었습니다.",
+                topNewsSources
+        );
+    }
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/dto/TopSourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/dto/TopSourceListResponse.java
@@ -1,0 +1,43 @@
+package site.kkokkio.domain.source.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import site.kkokkio.domain.source.dto.TopSourceItemDto;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "싱시간 인기 출처 목록 응답 DTO (페이지네이션 포함)")
+public record TopSourceListResponse(
+        List<TopSourceItemDto> list,
+        PaginationMeta meta
+) {
+    @Builder
+    private record PaginationMeta(
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext,
+            boolean hasPrevious
+    ) {
+    }
+
+    public static TopSourceListResponse from(Page<TopSourceItemDto> topSourceItemDtoPage) {
+        PaginationMeta paginationMeta = PaginationMeta.builder()
+                .page(topSourceItemDtoPage.getNumber())
+                .size(topSourceItemDtoPage.getSize())
+                .totalElements(topSourceItemDtoPage.getTotalElements())
+                .totalPages(topSourceItemDtoPage.getTotalPages())
+                .hasNext(topSourceItemDtoPage.hasNext())
+                .hasPrevious(topSourceItemDtoPage.hasPrevious())
+                .build();
+
+        return TopSourceListResponse.builder()
+                .list(topSourceItemDtoPage.getContent())
+                .meta(paginationMeta)
+                .build();
+    }
+}

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/dto/TopSourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/dto/TopSourceListResponse.java
@@ -15,7 +15,7 @@ public record TopSourceListResponse(
         PaginationMeta meta
 ) {
     @Builder
-    private record PaginationMeta(
+    public record PaginationMeta(
             int page,
             int size,
             long totalElements,

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/dto/TopSourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/dto/TopSourceListResponse.java
@@ -2,14 +2,13 @@ package site.kkokkio.domain.source.controller.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
-import lombok.Getter;
 import org.springframework.data.domain.Page;
 import site.kkokkio.domain.source.dto.TopSourceItemDto;
 
 import java.util.List;
 
 @Builder
-@Schema(description = "싱시간 인기 출처 목록 응답 DTO (페이지네이션 포함)")
+@Schema(description = "실시간 인기 출처 목록 응답 DTO (페이지네이션 포함)")
 public record TopSourceListResponse(
         List<TopSourceItemDto> list,
         PaginationMeta meta

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/TopSourceItemDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/TopSourceItemDto.java
@@ -1,0 +1,29 @@
+package site.kkokkio.domain.source.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.NonNull;
+import site.kkokkio.domain.source.entity.Source;
+import site.kkokkio.global.enums.Platform;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "실시간 인기 출처 목록의 개별 항목 DTO")
+public record TopSourceItemDto(
+        @NonNull String url,
+        @NonNull String title,
+        @NonNull String thumbnailUrl,
+        @NonNull LocalDateTime publishedAt,
+        @NonNull Platform platform
+) {
+    public static TopSourceItemDto fromSource(Source source) {
+        return TopSourceItemDto.builder()
+                .url(source.getNormalizedUrl())
+                .title(source.getTitle())
+                .thumbnailUrl(source.getThumbnailUrl())
+                .publishedAt(source.getPublishedAt())
+                .platform(source.getPlatform())
+                .build();
+    }
+}

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
@@ -1,20 +1,16 @@
 package site.kkokkio.domain.source.repository;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
-
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import site.kkokkio.domain.source.entity.PostSource;
 import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
-import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
-import site.kkokkio.domain.keyword.entity.KeywordPostHourly;
-import site.kkokkio.domain.post.entity.Post;
+
+import java.util.List;
 
 @Repository
 public interface PostSourceRepository extends JpaRepository<PostSource, Long> {
@@ -62,7 +58,7 @@ public interface PostSourceRepository extends JpaRepository<PostSource, Long> {
 			FROM KeywordMetricHourly kmh
 			JOIN KeywordPostHourly kph
 			ON kph.id.bucketAt = kmh.id.bucketAt
-			AND kph.id.platform = kph.id.platform
+			AND kph.id.platform = kmh.id.platform
 			AND kph.id.keywordId = kmh.id.keywordId
 			JOIN kph.post p
 			JOIN PostSource ps

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
@@ -2,14 +2,19 @@ package site.kkokkio.domain.source.repository;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import site.kkokkio.domain.source.entity.PostSource;
+import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
+import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
+import site.kkokkio.domain.keyword.entity.KeywordPostHourly;
+import site.kkokkio.domain.post.entity.Post;
 
 @Repository
 public interface PostSourceRepository extends JpaRepository<PostSource, Long> {
@@ -25,5 +30,51 @@ public interface PostSourceRepository extends JpaRepository<PostSource, Long> {
 		@Param("postId") Long postId,
 		@Param("platform") Platform platform,
 		Pageable pageable
+	);
+
+	/**
+	 * 주어진 인기 키워드 ID 목록과 플랫폼에 해당하는 Source 엔티티들을
+	 * 관련 관계(keyword_metric_hourly -> keyword_post_hourly ->
+	 * post -> post_source -> source)를 따라 조회하고
+	 * 페이지네이션 및 인기순(키워드 점수 등) 정렬을 적용하여 반환합니다.
+	 * @param topKeywordIds 인기 키워드의 ID 목록.
+	 * @param platform 조회할 플랫폼 (YOUTUBE 또는 NAVER_NEWS).
+	 * @param pageable 페이지네이션 및 정렬 정보. Service에서 전달한 정렬 정보가 쿼리에 자동 반영됩니다.
+	 * @return 페이지네이션된 Source 엔티티 목록.
+	 */
+	@Query(
+	value = """
+			SELECT DISTINCT s
+			FROM KeywordMetricHourly kmh
+			JOIN KeywordPostHourly kph
+			ON kph.id.bucketAt = kmh.id.bucketAt
+			AND kph.id.platform = kmh.id.platform
+			AND kph.id.keywordId = kmh.id.keywordId
+			JOIN kph.post p
+			JOIN PostSource ps ON ps.post = p
+			JOIN ps.source s
+			WHERE kmh.id.keywordId
+			IN (:topKeywordIds)
+			AND s.platform = :platform
+			""",
+	countQuery = """
+			SELECT COUNT(DISTINCT s.fingerprint)
+			FROM KeywordMetricHourly kmh
+			JOIN KeywordPostHourly kph
+			ON kph.id.bucketAt = kmh.id.bucketAt
+			AND kph.id.platform = kph.id.platform
+			AND kph.id.keywordId = kmh.id.keywordId
+			JOIN kph.post p
+			JOIN PostSource ps
+			ON ps.post = p
+			JOIN ps.source s
+			WHERE kmh.id.keywordId
+			IN (:topKeywordIds)
+			AND s.platform = :platform
+			""")
+	Page<Source> findSourcesByTopKeywordIdsAndPlatform(
+			@Param("topKeywordIds") List<Long> topKeywordIds,
+			@Param("platform") Platform platform,
+			Pageable pageable
 	);
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
@@ -1,25 +1,36 @@
 package site.kkokkio.domain.source.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyResponse;
+import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
 import site.kkokkio.domain.post.service.PostService;
+import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.entity.PostSource;
+import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.domain.source.repository.PostSourceRepository;
 import site.kkokkio.global.enums.Platform;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true) // 조회 기능 위주라서 추가했습니다.
 public class SourceService {
 
 	private final PostSourceRepository postSourceRepository;
 	private final PostService postService;
 
 	private static final int MAX_SOURCE_COUNT_PER_POST = 10;
+	private final KeywordMetricHourlyService keywordMetricHourlyService;
 
 	public List<SourceDto> getTop10NewsSourcesByPostId(Long postId) {
 		postService.getPostById(postId);
@@ -45,5 +56,69 @@ public class SourceService {
 		return postSources.stream()
 			.map(ps -> SourceDto.from(ps.getSource()))
 			.toList();
+	}
+
+	/**
+	 * 실시간 인기 키워드와 관련된 Youtube Source 목록을 페이지네이션하여 조회
+	 * @param pageable 페이지네이션 및 정렬 정보.
+	 * @return 페이지네이션된 TopSourceListResponse 객체.
+	 */
+	public TopSourceListResponse getTopYoutubeSources(Pageable pageable) {
+
+		// 현재 시스템의 실시간 인기 키워드 목록(ID)을 가져옵니다. (데이터 파이프라인의 Task 2 결과물)
+		List<KeywordMetricHourlyResponse> topKeywords = keywordMetricHourlyService.findHourlyMetrics();
+		List<Long> topKeywordIds = topKeywords.stream()
+				.map(KeywordMetricHourlyResponse::keywordId)
+				.collect(Collectors.toList());
+
+		// 인기 키워드가 없으면 빈 페이지 반환
+		if (topKeywordIds.isEmpty()) {
+			return TopSourceListResponse.from(Page.empty(pageable));
+		}
+
+		// Repository에서 인기 키워드 ID 목록과 플랫폼(YOUTUBE), Pageable 정보를 사용하여 Source 엔티티들을 페이지네이션하여 조회
+		Page<Source> sourcePage = postSourceRepository.findSourcesByTopKeywordIdsAndPlatform(
+				topKeywordIds,
+				Platform.YOUTUBE,
+				pageable
+		);
+
+		// 조회된 Page<Source>를 Page<TopSourceItemDto>로 변환
+		Page<TopSourceItemDto> dtoPage = sourcePage.map(TopSourceItemDto::fromSource);
+
+		// Page<TopSourceItemDto>를 TopSourceListResponse 객체로 변환하여 반환
+		return TopSourceListResponse.from(dtoPage);
+	}
+
+	/**
+	 * 실시간 인기 키워드와 관련된 네이버 뉴스 Source 목록을 페이지네이션하여 조회
+	 * @param pageable 페이지네이션 및 정렬 정보.
+	 * @return 페이지네이션된 TopSourceListResponse 객체.
+	 */
+	public TopSourceListResponse getTopNaverNewsSources(Pageable pageable) {
+		
+		// 현재 시스템의 실시간 인기 키워드 목록(ID)을 가져옵니다. (데이터 파이프라인의 Task 2 결과물)
+		List<KeywordMetricHourlyResponse> topKeywords = keywordMetricHourlyService.findHourlyMetrics();
+		List<Long> topKeywordIds = topKeywords.stream()
+				.map(KeywordMetricHourlyResponse::keywordId)
+				.collect(Collectors.toList());
+
+		// 인기 키워드가 없으면 빈 페이지 반환
+		if (topKeywordIds.isEmpty()) {
+			return TopSourceListResponse.from(Page.empty(pageable));
+		}
+
+		// Repository에서 인기 키워드 ID 목록과 플랫폼(NAVER_NEWS), Pageable 정보를 사용하여 Source 엔티티들을 페이지네이션하여 조회
+		Page<Source> sourcePage = postSourceRepository.findSourcesByTopKeywordIdsAndPlatform(
+				topKeywordIds,
+				Platform.NAVER_NEWS,
+				pageable
+		);
+
+		// 조회된 Page<Source>를 Page<TopSourceItemDto>로 변환
+		Page<TopSourceItemDto> dtoPage = sourcePage.map(TopSourceItemDto::fromSource);
+
+		// Page<TopSourceItemDto>를 TopSourceListResponse 객체로 변환하여 반환
+		return TopSourceListResponse.from(dtoPage);
 	}
 }

--- a/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
@@ -1,23 +1,28 @@
 package site.kkokkio.domain.source.controller;
 
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.*;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
+import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
+import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = SourceControllerV1.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -30,87 +35,319 @@ class SourceControllerV1Test {
     private SourceService sourceService;
 
     @Test
-	@DisplayName("포스트의 출처 뉴스 조회 - 성공")
+    @DisplayName("포스트의 출처 뉴스 조회 - 성공")
     void getNewsSources_Success() throws Exception {
         // given
         List<SourceDto> mockNewsList = List.of(
-            new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"))
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"))
         );
         given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(mockNewsList);
 
         // when & then
         mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-            .andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
-            .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
-            .andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+                .andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
+                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
+                .andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
     }
 
     @Test
-	@DisplayName("포스트의 출처 뉴스 조회 - 데이터 없음")
+    @DisplayName("포스트의 출처 뉴스 조회 - 데이터 없음")
     void getNewsSources_EmptyList() throws Exception {
         // given
         given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(List.of());
 
         // when & then
         mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-            .andExpect(jsonPath("$.data.list").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+                .andExpect(jsonPath("$.data.list").isEmpty());
     }
 
     @Test
-	@DisplayName("포스트의 출처 뉴스 조회 - 잘못된 요청")
+    @DisplayName("포스트의 출처 뉴스 조회 - 잘못된 요청")
     void getNewsSources_InvalidPostId_BadRequest() throws Exception {
         // when & then
         mockMvc.perform(get("/api/v1/posts/{postId}/news", "invalidId"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.code").value("400"))
-            .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
     }
 
     @Test
-	@DisplayName("포스트의 출처 뉴스 조회 - 포스트 없음")
+    @DisplayName("포스트의 출처 뉴스 조회 - 포스트 없음")
     void getNewsSources_PostNotFound() throws Exception {
         // given
         given(sourceService.getTop10NewsSourcesByPostId(anyLong()))
-            .willThrow(new ServiceException("404", "해당 포스트를 찾을 수 없습니다."));
+                .willThrow(new ServiceException("404", "해당 포스트를 찾을 수 없습니다."));
 
         // when & then
         mockMvc.perform(get("/api/v1/posts/{postId}/news", 999L))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.code").value("404"))
-            .andExpect(jsonPath("$.message").value("해당 포스트를 찾을 수 없습니다."));
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("404"))
+                .andExpect(jsonPath("$.message").value("해당 포스트를 찾을 수 없습니다."));
     }
 
 
     @Test
-	@DisplayName("포스트의 출처 영상 조회 - 성공")
+    @DisplayName("포스트의 출처 영상 조회 - 성공")
     void getVideoSources_Success() throws Exception {
         // given
         List<SourceDto> mockVideoList = List.of(
-            new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목1", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목2", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목3", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목4", LocalDateTime.parse("2024-04-29T15:30:00")),
-            new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목5", LocalDateTime.parse("2024-04-29T15:30:00"))
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목1", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목2", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목3", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목4", LocalDateTime.parse("2024-04-29T15:30:00")),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목5", LocalDateTime.parse("2024-04-29T15:30:00"))
         );
         given(sourceService.getTop10VideoSourcesByPostId(anyLong())).willReturn(mockVideoList);
 
         // when & then
         mockMvc.perform(get("/api/v1/posts/{postId}/videos", 1L))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.code").value("200"))
-            .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-            .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
-            .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
-            .andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+                .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
+                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
+                .andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
+    }
+
+    @Test
+    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
+    void getTopYoutubeSources_Success() throws Exception {
+
+        /// given
+        // Mocking 할 서비스 메소드의 반환 값 생성
+        List<TopSourceItemDto> mockItemList = List.of(
+                TopSourceItemDto.builder()
+                        .url("https://youtube.com/watch?v=video1")
+                        .title("유튜브 인기 영상 제목 1")
+                        .thumbnailUrl("https://image.youtube1.jpg")
+                        .publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
+                        .platform(Platform.YOUTUBE)
+                        .build(),
+                TopSourceItemDto.builder()
+                        .url("https://youtube.com/watch?v=video2")
+                        .title("유튜브 인기 영상 제목 2")
+                        .thumbnailUrl("https://image.youtube2.jpg")
+                        .publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
+                        .platform(Platform.YOUTUBE)
+                        .build(),
+                TopSourceItemDto.builder()
+                        .url("https://youtube.com/watch?v=video3")
+                        .title("유튜브 인기 영상 제목 3")
+                        .thumbnailUrl("https://image.youtube3.jpg")
+                        .publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
+                        .platform(Platform.YOUTUBE)
+                        .build(),
+                TopSourceItemDto.builder()
+                        .url("https://youtube.com/watch?v=video4")
+                        .title("유튜브 인기 영상 제목 4")
+                        .thumbnailUrl("https://image.youtube4.jpg")
+                        .publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
+                        .platform(Platform.YOUTUBE)
+                        .build()
+        );
+
+        // Mocking할 Page<TopSourceItemDto> 객체 생성
+        Pageable mockPageable =
+                PageRequest.of(0, 5, Sort.by("score").descending());
+        Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, 100);
+
+        // Mocking할 최종 반환 객체 TopSourceListResponse 생성
+        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
+
+        // sousourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
+        // 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
+        given(sourceService.getTopYoutubeSources(any(Pageable.class)))
+                .willReturn(mockResponse);
+
+        /// when & then
+        // /api/v1/videos/top 엔드포인트로 GET 요청
+        mockMvc.perform(get("/api/v1/videos/top"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.list").isArray())
+                .andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
+                .andExpect(jsonPath("$.data.meta").exists())
+                
+                // 첫번째 값 검증
+                .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
+                .andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
+                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.youtube1.jpg"))
+                .andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
+                .andExpect(jsonPath("$.data.list[0].platform").value("YOUTUBE"))
+                
+                // data.meta 필드 값 검증
+                .andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
+                .andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
+                .andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
+                .andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
+                .andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
+                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
+    }
+
+    @Test
+    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 데이터 없음")
+    void getTopYoutubeSources_EmptyList() throws Exception {
+
+        /// given
+        // Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
+        Pageable mockPageable =
+                PageRequest.of(0, 5, Sort.by("score").descending());
+        Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
+
+        // Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
+        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
+
+        // sourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
+        // 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
+        given(sourceService.getTopYoutubeSources(any(Pageable.class))).willReturn(mockResponse);
+
+        /// when & then
+        // /api/v1/videos/top 엔드포인트로 GET 요청
+        mockMvc.perform(get("/api/v1/videos/top"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.list").isArray())
+                .andExpect(jsonPath("$.data.list").isEmpty())
+                .andExpect(jsonPath("$.data.meta").exists())
+
+                // data.met 필드 값 검증
+                .andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
+                .andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
+                .andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
+                .andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
+                .andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
+                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));;
+    }
+
+    @Test
+    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
+    void getTopNaverNewsSources_Success() throws Exception {
+
+        /// given
+        // Mocking 할 서비스 메소드의 반환 값 생성
+        List<TopSourceItemDto> mockItemList = List.of(
+                TopSourceItemDto.builder()
+                        .url("https://news.naver.com/article/1")
+                        .title("네이버 인기 뉴스 제목 1")
+                        .thumbnailUrl("https://image.naver.com/1.jpg")
+                        .publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
+                        .platform(Platform.NAVER_NEWS)
+                        .build(),
+                TopSourceItemDto.builder()
+                        .url("https://news.naver.com/article/2")
+                        .title("네이버 인기 뉴스 제목 2")
+                        .thumbnailUrl("https://image.naver.com/2.jpg")
+                        .publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
+                        .platform(Platform.NAVER_NEWS)
+                        .build(),
+                TopSourceItemDto.builder()
+                        .url("https://news.naver.com/article/3")
+                        .title("네이버 인기 뉴스 제목 3")
+                        .thumbnailUrl("https://image.naver.com/3.jpg")
+                        .publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
+                        .platform(Platform.NAVER_NEWS)
+                        .build(),
+                TopSourceItemDto.builder()
+                        .url("https://news.naver.com/article/4")
+                        .title("네이버 인기 뉴스 제목 4")
+                        .thumbnailUrl("https://image.naver.com/4.jpg")
+                        .publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
+                        .platform(Platform.NAVER_NEWS)
+                        .build()
+        );
+
+        // Mocking할 Page<TopSourceItemDto> 객체 생성
+        Pageable mockPageable =
+                PageRequest.of(0, 5, Sort.by("score").descending());
+        Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, 100);
+
+        // Mocking할 최종 반환 객체 TopSourceListResponse 생성
+        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
+
+        // sousourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
+        // 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
+        given(sourceService.getTopNaverNewsSources(any(Pageable.class)))
+                .willReturn(mockResponse);
+
+        /// when & then
+        // /api/v1/news/top 엔드포인트로 GET 요청
+        mockMvc.perform(get("/api/v1/news/top"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.list").isArray())
+                .andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
+                .andExpect(jsonPath("$.data.meta").exists())
+
+                // 첫번째 값 검증
+                .andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
+                .andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
+                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.naver.com/1.jpg"))
+                .andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
+                .andExpect(jsonPath("$.data.list[0].platform").value("NAVER_NEWS"))
+
+                // data.meta 필드 값 검증
+                .andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
+                .andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
+                .andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
+                .andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
+                .andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
+                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
+    }
+
+    @Test
+    @DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 데이터 없음")
+    void getTopNaverNewsSources_EmptyList() throws Exception {
+
+        /// given
+        // Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
+        Pageable mockPageable =
+                PageRequest.of(0, 5, Sort.by("score").descending());
+        Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
+
+        // Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
+        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
+
+        // sourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
+        // 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
+        given(sourceService.getTopNaverNewsSources(any(Pageable.class))).willReturn(mockResponse);
+
+        /// when & then
+        // /api/v1/news/top 엔드포인트로 GET 요청
+        mockMvc.perform(get("/api/v1/news/top"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.list").isArray())
+                .andExpect(jsonPath("$.data.list").isEmpty())
+                .andExpect(jsonPath("$.data.meta").exists())
+
+                // data.met 필드 값 검증
+                .andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
+                .andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
+                .andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
+                .andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
+                .andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
+                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));;
     }
 }

--- a/backend/src/test/java/site/kkokkio/domain/source/service/SourceServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/service/SourceServiceTest.java
@@ -1,28 +1,36 @@
 package site.kkokkio.domain.source.service;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
-import static org.mockito.BDDMockito.*;
-
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
-
+import org.springframework.data.domain.*;
+import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyResponse;
+import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
 import site.kkokkio.domain.post.entity.Post;
 import site.kkokkio.domain.post.service.PostService;
+import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.entity.PostSource;
 import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.domain.source.repository.PostSourceRepository;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SourceServiceTest {
@@ -36,15 +44,18 @@ class SourceServiceTest {
     @Mock
     private PostSourceRepository postSourceRepository;
 
+    @Mock
+    private KeywordMetricHourlyService keywordMetricHourlyService;
+
     @Test
-	@DisplayName("뉴스 출처 10개 조회 - 성공")
+    @DisplayName("뉴스 출처 10개 조회 - 성공")
     void getTop10NewsSourcesByPostId_success() {
         // given
         Long postId = 1L;
         Platform platform = Platform.NAVER_NEWS;
         PageRequest pageRequest = PageRequest.of(0, 10);
 
-		Post dummyPost = Post.builder().id(postId).build();
+        Post dummyPost = Post.builder().id(postId).build();
 
         Source s1 = Source.builder()
                 .fingerprint("f1")
@@ -91,14 +102,14 @@ class SourceServiceTest {
     }
 
     @Test
-	@DisplayName("뉴스 출처 10개 조회 - 데이터 없음")
+    @DisplayName("뉴스 출처 10개 조회 - 데이터 없음")
     void getTop10NewsSourcesByPostId_emptySourceList() {
         // given
         Long postId = 1L;
         Platform platform = Platform.NAVER_NEWS;
         PageRequest pageRequest = PageRequest.of(0, 10);
 
-		Post dummyPost = Post.builder().id(postId).build();
+        Post dummyPost = Post.builder().id(postId).build();
 
         given(postService.getPostById(eq(postId))).willReturn(dummyPost);
         given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
@@ -112,7 +123,7 @@ class SourceServiceTest {
     }
 
     @Test
-	@DisplayName("뉴스 출처 10개 조회 - 포스트 없음")
+    @DisplayName("뉴스 출처 10개 조회 - 포스트 없음")
     void getTop10NewsSourcesByPostId_postNotFound() {
         // given
         Long postId = 999L;
@@ -128,14 +139,14 @@ class SourceServiceTest {
 
 
     @Test
-	@DisplayName("영상 출처 10개 조회 - 성공")
+    @DisplayName("영상 출처 10개 조회 - 성공")
     void getTop10VideoSourcesByPostId_success() {
         // given
         Long postId = 1L;
         Platform platform = Platform.YOUTUBE;
         PageRequest pageRequest = PageRequest.of(0, 10);
 
-		Post dummyPost = Post.builder().id(postId).build();
+        Post dummyPost = Post.builder().id(postId).build();
 
         Source s1 = Source.builder()
                 .fingerprint("f1")
@@ -181,4 +192,437 @@ class SourceServiceTest {
         assertThat(result.get(1).title()).isEqualTo("유튜브2");
     }
 
+    @Test
+    @DisplayName("실시간 인기 유튜브 Source 조회 - 성공")
+    void getTopYoutubeSources_Success() {
+
+        /// given
+        // Mocking할 인기 키워드 목록 생성
+        List<KeywordMetricHourlyResponse> mockTopKeywords = Arrays.asList(
+                new KeywordMetricHourlyResponse(1L, "키워드 1", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 1000, 90),
+                new KeywordMetricHourlyResponse(2L, "키워드 2", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 800, 70),
+                new KeywordMetricHourlyResponse(3L, "키워드 3", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 300, 30),
+                new KeywordMetricHourlyResponse(4L, "키워드 4", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 50, 77),
+                new KeywordMetricHourlyResponse(5L, "키워드 5", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 650, 70),
+                new KeywordMetricHourlyResponse(6L, "키워드 6", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 70, 86),
+                new KeywordMetricHourlyResponse(7L, "키워드 7", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 120, 43),
+                new KeywordMetricHourlyResponse(8L, "키워드 8", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 665, 86),
+                new KeywordMetricHourlyResponse(9L, "키워드 9", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 505, 42),
+                new KeywordMetricHourlyResponse(10L, "키워드 10", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 404, 55)
+        );
+
+        // Mocking할 Repository의 반환 값 생성
+        List<Source> mockSourceList = Arrays.asList(
+                Source.builder().fingerprint("fp1").normalizedUrl("http://youtube.com/v1").title("영상제목1")
+                        .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp2").normalizedUrl("http://youtube.com/v2").title("영상제목2")
+                        .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp3").normalizedUrl("http://youtube.com/v3").title("영상제목3")
+                        .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp4").normalizedUrl("http://youtube.com/v4").title("영상제목4")
+                        .thumbnailUrl("thumb4").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp5").normalizedUrl("http://youtube.com/v5").title("영상제목5")
+                        .thumbnailUrl("thumb5").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp6").normalizedUrl("http://youtube.com/v6").title("영상제목6")
+                        .thumbnailUrl("thumb6").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp7").normalizedUrl("http://youtube.com/v7").title("영상제목7")
+                        .thumbnailUrl("thumb7").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp8").normalizedUrl("http://youtube.com/v8").title("영상제목8")
+                        .thumbnailUrl("thumb8").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp9").normalizedUrl("http://youtube.com/v9").title("영상제목9")
+                        .thumbnailUrl("thumb9").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+                Source.builder().fingerprint("fp10").normalizedUrl("http://youtube.com/v10").title("영상제목10")
+                        .thumbnailUrl("thumb10").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build()
+        );
+
+        // Service 메소드에 전달될 Pageable 객체 (컨트롤러에서 넘어올 형태)
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+        // Repository가 반환할 Mock Page<Source> 객체 생성
+        Page<Source> mockSourcePage = new PageImpl<>(mockSourceList, pageable, 50);
+
+        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 mockTopKeywords 반환
+        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+        // postSourceRepository.findSourcesByTopKeywordIdsAndPlatform() 호출 시 mockSourcePage 반환
+        given(postSourceRepository.findSourcesByTopKeywordIdsAndPlatform(
+                anyList(),
+                eq(Platform.YOUTUBE),
+                eq(pageable)
+        )).willReturn(mockSourcePage);
+
+        /// when
+        // 테스트 대상 메소드 호출
+        TopSourceListResponse result = sourceService.getTopYoutubeSources(pageable);
+
+        /// then
+        assertThat(result).isNotNull();
+        assertThat(result.list()).isNotNull().hasSize(mockTopKeywords.size());
+        assertThat(result.meta()).isNotNull();
+
+        // list 안의 TopSourceItemDto 객체들이 올바르게 변환되었는지 검증
+        assertThat(result.list().getFirst().url())
+                .isEqualTo(mockSourceList.getFirst().getNormalizedUrl());
+        assertThat(result.list().getFirst().title())
+                .isEqualTo(mockSourceList.getFirst().getTitle());
+        assertThat(result.list().getFirst().thumbnailUrl())
+                .isEqualTo(mockSourceList.getFirst().getThumbnailUrl());
+        assertThat(result.list().getFirst().publishedAt())
+                .isEqualTo(mockSourceList.getFirst().getPublishedAt());
+        assertThat(result.list().getFirst().platform())
+                .isEqualTo(mockSourceList.getFirst().getPlatform());
+
+        // Mock SourceList의 두 번째 항목도 검증
+        assertThat(result.list().get(1).url())
+                .isEqualTo(mockSourceList.get(1).getNormalizedUrl());
+        assertThat(result.list().get(1).title())
+                .isEqualTo(mockSourceList.get(1).getTitle());
+        assertThat(result.list().get(1).thumbnailUrl())
+                .isEqualTo(mockSourceList.get(1).getThumbnailUrl());
+        assertThat(result.list().get(1).publishedAt())
+                .isEqualTo(mockSourceList.get(1).getPublishedAt());
+        assertThat(result.list().get(1).platform())
+                .isEqualTo(mockSourceList.get(1).getPlatform());
+
+        // meta 정보가 Mock Page에서 올바르게 변환되었는지 검증
+        assertThat(result.meta().page()).isEqualTo(mockSourcePage.getNumber());
+        assertThat(result.meta().size()).isEqualTo(mockSourcePage.getSize());
+        assertThat(result.meta().totalElements()).isEqualTo(mockSourcePage.getTotalElements());
+        assertThat(result.meta().totalPages()).isEqualTo(mockSourcePage.getTotalPages());
+        assertThat(result.meta().hasNext()).isEqualTo(mockSourcePage.hasNext());
+        assertThat(result.meta().hasPrevious()).isEqualTo(mockSourcePage.hasPrevious());
+
+        // Service 메소드가 의존하는 다른 메소드들을 올바르게 호출했는지 검증
+        verify(keywordMetricHourlyService, times(1))
+                .findHourlyMetrics();
+        verify(postSourceRepository, times(1))
+                .findSourcesByTopKeywordIdsAndPlatform(
+                        anyList(),
+                        eq(Platform.YOUTUBE),
+                        eq(pageable)
+                );
+    }
+
+    @Test
+    @DisplayName("실시간 인기 유튜브 Source 조회 - 인기 키워드 목록이 비어있을 때")
+    void getTopYoutubeSources_EmptyKeywords() {
+
+        /// given
+        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 빈 리스트 반환하도록 Mocking
+        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(Collections.emptyList());
+
+        // Service 메소드에 전달될 Pageable 객체
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+        /// when
+        // 테스트 대상 메소드 호출
+        TopSourceListResponse result = sourceService.getTopYoutubeSources(pageable);
+
+        /// then
+        assertThat(result).isNotNull();
+        assertThat(result.list()).isNotNull().isEmpty();
+
+        // Page.empty(pageable)이 생성하는 Page 객체의 메타 정보를 기준으로 검증
+        Page<TopSourceItemDto> emptyPage = Page.empty(pageable);
+
+        assertThat(result.meta()).isNotNull();
+        assertThat(result.meta().page()).isEqualTo(emptyPage.getNumber());
+        assertThat(result.meta().size()).isEqualTo(emptyPage.getSize());
+        assertThat(result.meta().totalElements()).isEqualTo(emptyPage.getTotalElements());
+        assertThat(result.meta().totalPages()).isEqualTo(emptyPage.getTotalPages());
+        assertThat(result.meta().hasNext()).isEqualTo(emptyPage.hasNext());
+        assertThat(result.meta().hasPrevious()).isEqualTo(emptyPage.hasPrevious());
+
+        // Service가 Repository 메소드를 호출하지 않았는지 검증
+        verify(postSourceRepository, never()).findSourcesByTopKeywordIdsAndPlatform(
+                anyList(),
+                any(Platform.class),
+                any(Pageable.class)
+        );
+
+        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+    }
+
+    @Test
+    @DisplayName("실시간 인기 유튜브 Source 조회 - Repository가 빈 Page를 반환할 때")
+    void getTopYoutubeSources_RepositoryReturnsEmptyPage() {
+
+        /// given
+        // Mocking할 인기 키워드 목록 생성
+        List<KeywordMetricHourlyResponse> mockTopKeywords = List.of(
+                new KeywordMetricHourlyResponse(1L, "키워드 1", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 1000, 90)
+        );
+
+        // Mocking할 Repository의 반환 값 (빈 Page<Source>) 생성
+        List<Source> mockEmptySourceList = Collections.emptyList();
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+        // Repository가 반환할 Mock 빈 Page<Source> 객체 생성 (내용은 비어있고, 전체 개수는 0)
+        Page<Source> mockEmptySourcePage = new PageImpl<>(mockEmptySourceList, pageable, 0);
+
+        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 비어있지 않은 목록 반환
+        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+        // postSourceRepository.findSourcesByTopKeywordIdsAndPlatform() 호출 시 빈 mockEmptySourcePage 반환
+        given(postSourceRepository.findSourcesByTopKeywordIdsAndPlatform(
+                anyList(),
+                eq(Platform.YOUTUBE),
+                eq(pageable)
+        )).willReturn(mockEmptySourcePage);
+
+        /// when
+        // 테스트 대상 메소드 호출
+        TopSourceListResponse result = sourceService.getTopYoutubeSources(pageable);
+
+        /// then
+        assertThat(result).isNotNull();
+        assertThat(result.list()).isNotNull().isEmpty();
+        assertThat(result.meta()).isNotNull();
+        assertThat(result.meta().page()).isEqualTo(mockEmptySourcePage.getNumber());
+        assertThat(result.meta().size()).isEqualTo(mockEmptySourcePage.getSize());
+        assertThat(result.meta().totalElements()).isEqualTo(mockEmptySourcePage.getTotalElements());
+        assertThat(result.meta().totalPages()).isEqualTo(mockEmptySourcePage.getTotalPages());
+        assertThat(result.meta().hasNext()).isEqualTo(mockEmptySourcePage.hasNext());
+        assertThat(result.meta().hasPrevious()).isEqualTo(mockEmptySourcePage.hasPrevious());
+
+        // Service가 Repository 메소드를 호출했는지 검증 (인기 키워드가 있으므로 호출되어야 함)
+        verify(postSourceRepository, times(1))
+                .findSourcesByTopKeywordIdsAndPlatform(
+                        anyList(),
+                        eq(Platform.YOUTUBE),
+                        eq(pageable)
+                );
+
+        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+    }
+
+    @Test
+    @DisplayName("실시간 인기 네이버 뉴스 Source 조회 - 성공")
+    void getTopNaverNewsSources_Success() {
+
+        /// given
+        // Mocking할 인기 키워드 목록 생성
+        List<KeywordMetricHourlyResponse> mockTopKeywords = Arrays.asList(
+                new KeywordMetricHourlyResponse(1L, "키워드 1", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 1000, 90),
+                new KeywordMetricHourlyResponse(2L, "키워드 2", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 800, 70),
+                new KeywordMetricHourlyResponse(3L, "키워드 3", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 300, 30),
+                new KeywordMetricHourlyResponse(4L, "키워드 4", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 50, 77),
+                new KeywordMetricHourlyResponse(5L, "키워드 5", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 650, 70),
+                new KeywordMetricHourlyResponse(6L, "키워드 6", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 70, 86),
+                new KeywordMetricHourlyResponse(7L, "키워드 7", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 120, 43),
+                new KeywordMetricHourlyResponse(8L, "키워드 8", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 665, 86),
+                new KeywordMetricHourlyResponse(9L, "키워드 9", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 505, 42),
+                new KeywordMetricHourlyResponse(10L, "키워드 10", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 404, 55)
+        );
+
+        // Mocking할 Repository의 반환 값 생성
+        List<Source> mockSourceList = Arrays.asList(
+                Source.builder().fingerprint("fp1").normalizedUrl("http://news.naver.com/article/1").title("뉴스제목1")
+                        .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp2").normalizedUrl("http://news.naver.com/article/2").title("뉴스제목2")
+                        .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp3").normalizedUrl("http://news.naver.com/article/3").title("뉴스제목3")
+                        .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp4").normalizedUrl("http://news.naver.com/article/4").title("뉴스제목4")
+                        .thumbnailUrl("thumb4").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp5").normalizedUrl("http://news.naver.com/article/5").title("뉴스제목5")
+                        .thumbnailUrl("thumb5").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp6").normalizedUrl("http://news.naver.com/article/6").title("뉴스제목6")
+                        .thumbnailUrl("thumb6").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp7").normalizedUrl("http://news.naver.com/article/7").title("뉴스제목7")
+                        .thumbnailUrl("thumb7").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp8").normalizedUrl("http://news.naver.com/article/8").title("뉴스제목8")
+                        .thumbnailUrl("thumb8").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp9").normalizedUrl("http://news.naver.com/article/9").title("뉴스제목9")
+                        .thumbnailUrl("thumb9").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+                Source.builder().fingerprint("fp10").normalizedUrl("http://news.naver.com/article/10").title("뉴스제목10")
+                        .thumbnailUrl("thumb10").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build()
+        );
+
+        // Service 메소드에 전달될 Pageable 객체 (컨트롤러에서 넘어올 형태)
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+        // Repository가 반환할 Mock Page<Source> 객체 생성
+        Page<Source> mockSourcePage = new PageImpl<>(mockSourceList, pageable, 50);
+
+        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 mockTopKeywords 반환
+        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+        // postSourceRepository.findSourcesByTopKeywordIdsAndPlatform() 호출 시 mockSourcePage 반환
+        given(postSourceRepository.findSourcesByTopKeywordIdsAndPlatform(
+                anyList(),
+                eq(Platform.NAVER_NEWS),
+                eq(pageable)
+        )).willReturn(mockSourcePage);
+
+        /// when
+        // 테스트 대상 메소드 호출
+        TopSourceListResponse result = sourceService.getTopNaverNewsSources(pageable);
+
+        /// then
+        assertThat(result).isNotNull();
+        assertThat(result.list()).isNotNull().hasSize(mockTopKeywords.size());
+        assertThat(result.meta()).isNotNull();
+
+        // list 안의 TopSourceItemDto 객체들이 올바르게 변환되었는지 검증
+        assertThat(result.list().getFirst().url())
+                .isEqualTo(mockSourceList.getFirst().getNormalizedUrl());
+        assertThat(result.list().getFirst().title())
+                .isEqualTo(mockSourceList.getFirst().getTitle());
+        assertThat(result.list().getFirst().thumbnailUrl())
+                .isEqualTo(mockSourceList.getFirst().getThumbnailUrl());
+        assertThat(result.list().getFirst().publishedAt())
+                .isEqualTo(mockSourceList.getFirst().getPublishedAt());
+        assertThat(result.list().getFirst().platform())
+                .isEqualTo(mockSourceList.getFirst().getPlatform());
+
+        // Mock SourceList의 두 번째 항목도 검증
+        assertThat(result.list().get(1).url())
+                .isEqualTo(mockSourceList.get(1).getNormalizedUrl());
+        assertThat(result.list().get(1).title())
+                .isEqualTo(mockSourceList.get(1).getTitle());
+        assertThat(result.list().get(1).thumbnailUrl())
+                .isEqualTo(mockSourceList.get(1).getThumbnailUrl());
+        assertThat(result.list().get(1).publishedAt())
+                .isEqualTo(mockSourceList.get(1).getPublishedAt());
+        assertThat(result.list().get(1).platform())
+                .isEqualTo(mockSourceList.get(1).getPlatform());
+
+        // meta 정보가 Mock Page에서 올바르게 변환되었는지 검증
+        assertThat(result.meta().page()).isEqualTo(mockSourcePage.getNumber());
+        assertThat(result.meta().size()).isEqualTo(mockSourcePage.getSize());
+        assertThat(result.meta().totalElements()).isEqualTo(mockSourcePage.getTotalElements());
+        assertThat(result.meta().totalPages()).isEqualTo(mockSourcePage.getTotalPages());
+        assertThat(result.meta().hasNext()).isEqualTo(mockSourcePage.hasNext());
+        assertThat(result.meta().hasPrevious()).isEqualTo(mockSourcePage.hasPrevious());
+
+        // Service 메소드가 의존하는 다른 메소드들을 올바르게 호출했는지 검증
+        verify(keywordMetricHourlyService, times(1))
+                .findHourlyMetrics();
+        verify(postSourceRepository, times(1))
+                .findSourcesByTopKeywordIdsAndPlatform(
+                        anyList(),
+                        eq(Platform.NAVER_NEWS),
+                        eq(pageable)
+                );
+    }
+
+    @Test
+    @DisplayName("실시간 인기 네이버 뉴스 Source 조회 - 인기 키워드 목록이 비어있을 때")
+    void getTopNaverNewsSources_EmptyKeywords() {
+
+        /// given
+        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 빈 리스트 반환하도록 Mocking
+        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(Collections.emptyList());
+
+        // Service 메소드에 전달될 Pageable 객체
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+        /// when
+        // 테스트 대상 메소드 호출
+        TopSourceListResponse result = sourceService.getTopNaverNewsSources(pageable);
+
+        /// then
+        assertThat(result).isNotNull();
+        assertThat(result.list()).isNotNull().isEmpty();
+
+        // Page.empty(pageable)이 생성하는 Page 객체의 메타 정보를 기준으로 검증
+        Page<TopSourceItemDto> emptyPage = Page.empty(pageable);
+
+        assertThat(result.meta()).isNotNull();
+        assertThat(result.meta().page()).isEqualTo(emptyPage.getNumber());
+        assertThat(result.meta().size()).isEqualTo(emptyPage.getSize());
+        assertThat(result.meta().totalElements()).isEqualTo(emptyPage.getTotalElements());
+        assertThat(result.meta().totalPages()).isEqualTo(emptyPage.getTotalPages());
+        assertThat(result.meta().hasNext()).isEqualTo(emptyPage.hasNext());
+        assertThat(result.meta().hasPrevious()).isEqualTo(emptyPage.hasPrevious());
+
+        // Service가 Repository 메소드를 호출하지 않았는지 검증
+        verify(postSourceRepository, never()).findSourcesByTopKeywordIdsAndPlatform(
+                anyList(),
+                any(Platform.class),
+                any(Pageable.class)
+        );
+
+        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+    }
+
+    @Test
+    @DisplayName("실시간 인기 네이버 뉴스 Source 조회 - Repository가 빈 Page를 반환할 때")
+    void getTopNaverNewsSources_RepositoryReturnsEmptyPage() {
+
+        /// given
+        // Mocking할 인기 키워드 목록 생성
+        List<KeywordMetricHourlyResponse> mockTopKeywords = List.of(
+                new KeywordMetricHourlyResponse(1L, "키워드 1", Platform.GOOGLE_TREND,
+                        LocalDateTime.now(), 1000, 90)
+        );
+
+        // Mocking할 Repository의 반환 값 (빈 Page<Source>) 생성
+        List<Source> mockEmptySourceList = Collections.emptyList();
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+        // Repository가 반환할 Mock 빈 Page<Source> 객체 생성 (내용은 비어있고, 전체 개수는 0)
+        Page<Source> mockEmptySourcePage = new PageImpl<>(mockEmptySourceList, pageable, 0);
+
+        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 비어있지 않은 목록 반환
+        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+        // postSourceRepository.findSourcesByTopKeywordIdsAndPlatform() 호출 시 빈 mockEmptySourcePage 반환
+        given(postSourceRepository.findSourcesByTopKeywordIdsAndPlatform(
+                anyList(),
+                eq(Platform.NAVER_NEWS),
+                eq(pageable)
+        )).willReturn(mockEmptySourcePage);
+
+        /// when
+        // 테스트 대상 메소드 호출
+        TopSourceListResponse result = sourceService.getTopNaverNewsSources(pageable);
+
+        /// then
+        assertThat(result).isNotNull();
+        assertThat(result.list()).isNotNull().isEmpty();
+        assertThat(result.meta()).isNotNull();
+        assertThat(result.meta().page()).isEqualTo(mockEmptySourcePage.getNumber());
+        assertThat(result.meta().size()).isEqualTo(mockEmptySourcePage.getSize());
+        assertThat(result.meta().totalElements()).isEqualTo(mockEmptySourcePage.getTotalElements());
+        assertThat(result.meta().totalPages()).isEqualTo(mockEmptySourcePage.getTotalPages());
+        assertThat(result.meta().hasNext()).isEqualTo(mockEmptySourcePage.hasNext());
+        assertThat(result.meta().hasPrevious()).isEqualTo(mockEmptySourcePage.hasPrevious());
+
+        // Service가 Repository 메소드를 호출했는지 검증 (인기 키워드가 있으므로 호출되어야 함)
+        verify(postSourceRepository, times(1))
+                .findSourcesByTopKeywordIdsAndPlatform(
+                        anyList(),
+                        eq(Platform.NAVER_NEWS),
+                        eq(pageable)
+                );
+
+        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> 25

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
api 명세서 (/news/top): https://www.notion.so/news-top-1e03550b7b5580ffbc13d6998ce0a6ae?pvs=4
api 명세서 (/videos/top): https://www.notion.so/videos-top-1e03550b7b558096a4e7fd0e09c57234?pvs=4
기반 작업 완료

1. doppler로 .env에 유튜브 API 키 추가
2. 인기 키워드 top 10을 통해 유튜브와 네이버 뉴스 받아 출력(페이지네이션 적용) (데이터 파이프 라인 기반으로 구현)
   - KeywordMetricHourlyService의 findHourlyMetrics(가장 최근의 인기 키워드 10개 조회)로 키워드 조회
   - PostSourceRepository의 findSourcesByTopKeywordIdsAndPlatform 메소드를 호출하여 DB 조회.
   - 조회 결과를 TopSourceItemDto 및 PaginationMeta를 포함하는 TopSourceListResponse 객체로 변환하는 로직.
   - 인기 키워드가 없거나 Repository 조회 결과가 없는 경우 빈 응답을 반환하는 엣지 케이스 처리 로직 포함.
3. SourceController, SourceService tdd 구현

## 향후 해야 할 일
1. 유튜브 api 연결
2. 코드 리펙토링
3. 주요 오류 처리 ServiceException에서 구현

아마 api 연결하면서 수정할 부분이 많아질 수도 있습니다. 참고해 주세요!

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
우선 **PostSourceRepository**에서 findSourcesByTopKeywordIdsAndPlatform를 사용했는데, 좀 복잡한 쿼리를 짰습니다. 아래에 써두겠습니다.

@Query(
value = """
       SELECT DISTINCT s -- (1) Source 엔티티를 중복 없이 선택 (별칭 s)
       FROM KeywordMetricHourly kmh -- (2) KeywordMetricHourly 엔티티 (별칭 kmh)에서 시작
       JOIN KeywordPostHourly kph -- (3) kmh와 kph 조인 시작
       ON kph.id.bucketAt = kmh.id.bucketAt -- (4) kph의 복합키 일부 (bucketAt)로 조인
       AND kph.id.platform = kmh.id.platform -- (5) kph의 복합키 일부 (platform)로 조인
       AND kph.id.keywordId = kmh.id.keywordId -- (6) kph의 복합키 일부 (keywordId)로 조인 (kmh의 ID와 연결)
       JOIN kph.post p -- (7) kph 엔티티의 'post' 필드(ManyToOne)를 사용하여 Post 엔티티 (별칭 p)와 조인
       JOIN PostSource ps ON ps.post = p -- (8) ps 엔티티의 'post' 필드(ManyToOne)를 사용하여 p 엔티티와 조인
       JOIN ps.source s -- (9) ps 엔티티의 'source' 필드(ManyToOne)를 사용하여 Source 엔티티 (별칭 s)와 조인
       WHERE kmh.id.keywordId -- (10) 필터링 시작
       IN (:topKeywordIds) -- (11) kmh의 keywordId가 파라미터 topKeywordIds 목록 안에 있는지 검사
       AND s.platform = :platform -- (12) 최종 선택된 s의 platform이 파라미터 platform과 일치하는지 검사
       ORDER BY kmh.score DESC, s.publishedAt DESC -- (13) 인기 점수(kmh.score)와 발행일(s.publishedAt)로 정렬 (Service의 Pageable 정렬 정보와 결합됨)
       """,
countQuery = """
       SELECT COUNT(DISTINCT s.fingerprint) -- (카운트 쿼리) 중복 없는 s의 fingerprint 개수를 셈
       FROM KeywordMetricHourly kmh -- (카운트 쿼리) kmh에서 시작
       JOIN KeywordPostHourly kph
       ON kph.id.bucketAt = kmh.id.bucketAt
       AND kph.id.platform = kmh.id.platform
       AND kph.id.keywordId = kmh.id.keywordId
       JOIN kph.post p
       JOIN PostSource ps
       ON ps.post = p
       JOIN ps.source s
       WHERE kmh.id.keywordId -- (카운트 쿼리) 필터링 시작
       IN (:topKeywordIds) -- (카운트 쿼리) kmh의 keywordId가 파라미터 topKeywordIds 목록 안에 있는지 검사
       AND s.platform = :platform -- (카운트 쿼리) 최종 선택된 s의 platform이 파라미터 platform과 일치하는지 검사
       """)
Page<Source> findSourcesByTopKeywordIdsAndPlatform(
       @Param("topKeywordIds") List<Long> topKeywordIds,
       @Param("platform") Platform platform,
       Pageable pageable // 페이지네이션 및 정렬 정보 자동 적용
);
closes #25