### PR TITLE
Feat/38 swagger custom annotation

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
@@ -25,6 +25,8 @@ import site.kkokkio.domain.comment.service.CommentService;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.dto.Empty;
 import site.kkokkio.global.dto.RsData;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -34,6 +36,7 @@ public class CommentControllerV1 {
 	private final CommentService commentService;
 
 	@Operation(summary = "댓글 목록 조회")
+	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_3})
 	@GetMapping("/posts/{postId}/comments")
 	public RsData<CommentListResponse> getCommentList(
 		@PathVariable("postId") Long postId,
@@ -51,6 +54,7 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 작성")
+	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_3})
 	@PostMapping("/posts/{postId}/comments")
 	public RsData<CommentDto> createComment(
 		@PathVariable("postId") Long postId,
@@ -65,6 +69,7 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 수정")
+	@ApiErrorCodeExamples({ErrorCode.COMMENT_UPDATE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@PatchMapping("/comments/{commentId}")
 	public RsData<CommentDto> updateComment(
 		@PathVariable("commentId") Long commentId,
@@ -80,6 +85,7 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 삭제")
+	@ApiErrorCodeExamples({ErrorCode.COMMENT_DELETE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@DeleteMapping("/comments/{commentId}")
 	public RsData<Empty> deleteComment(
 		@PathVariable("commentId") Long commentId,
@@ -93,6 +99,8 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 좋아요")
+	@ApiErrorCodeExamples({ErrorCode.COMMENT_LIKE_BAD_REQUEST, ErrorCode.COMMENT_LIKE_FORBIDDEN,
+		ErrorCode.COMMENT_NOT_FOUND})
 	@PostMapping("/comments/{commentId}/like")
 	public RsData<CommentDto> likeComment(
 		@PathVariable("commentId") Long commentId,

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1.java
@@ -14,6 +14,8 @@ import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyResponse;
 import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
 import site.kkokkio.global.dto.RsData;
 import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +25,7 @@ public class KeywordMetricHourlyControllerV1 {
 	private final KeywordMetricHourlyService keywordMetricHourlyService;
 
 	@GetMapping("/top")
+	@ApiErrorCodeExamples({ErrorCode.KEYWORDS_NOT_FOUND_1})
 	@Operation(summary = "실시간 키워드 리스트", description = "실시간 키워드 Top 10개 보기")
 	public RsData<List<KeywordMetricHourlyResponse>> getHourlyMetrics() {
 		try {

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -21,6 +21,8 @@ import site.kkokkio.domain.member.dto.EmailVerificationRequest;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
 import site.kkokkio.global.dto.RsData;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
 import site.kkokkio.global.util.JwtUtils;
 
 @Tag(name = "Member API", description = "회원 관련 기능을 제공")
@@ -35,6 +37,7 @@ public class MemberControllerV1 {
 
 	// 회원가입
 	@Operation(summary = "회원가입")
+	@ApiErrorCodeExamples({ErrorCode.EMAIL_ALREADY_EXIST, ErrorCode.NICKNAME_ALREADY_EXIST})
 	@PostMapping("/signup")
 	public RsData<MemberResponse> createMember(@RequestBody @Validated MemberSignUpRequest request) {
 		MemberResponse memberResponse = memberService.createMember(request);
@@ -43,6 +46,7 @@ public class MemberControllerV1 {
 
 	// 로그인
 	@Operation(summary = "로그인")
+	@ApiErrorCodeExamples({ErrorCode.EMAIL_NOT_FOUND, ErrorCode.PASSWORD_UNAUTHORIZED})
 	@PostMapping("/login")
 	public RsData<MemberLoginResponse> login(
 		@RequestBody @Validated MemberLoginRequest request,

--- a/backend/src/main/java/site/kkokkio/domain/post/controller/PostControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/controller/PostControllerV1.java
@@ -15,6 +15,8 @@ import site.kkokkio.domain.post.controller.dto.TopPostResponse;
 import site.kkokkio.domain.post.dto.PostDto;
 import site.kkokkio.domain.post.service.PostService;
 import site.kkokkio.global.dto.RsData;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
 
 @RestController
 @RequestMapping("/api/v1/posts")
@@ -24,6 +26,7 @@ public class PostControllerV1 {
 	private final PostService postService;
 
 	@Operation(summary = "포스트 조회")
+	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_2})
 	@GetMapping("/{postId}")
 	public RsData<PostDetailResponse> getPostById(@PathVariable Long postId) {
 		PostDto postDto = postService.getPostWithKeywordById(postId);
@@ -43,6 +46,7 @@ public class PostControllerV1 {
 	}
 
 	@Operation(summary = "실시간 키워드에 해당하는 포스트 리스트 조회")
+	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_2})
 	@GetMapping("/top")
 	public RsData<List<TopPostResponse>> getTopKeywordPosts() {
 		List<PostDto> postDtos = postService.getTopPostsWithKeyword();

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
@@ -1,8 +1,7 @@
 package site.kkokkio.domain.source.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -11,13 +10,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.source.controller.dto.SourceListResponse;
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
 import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.dto.RsData;
-
-import java.util.List;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -27,6 +30,7 @@ public class SourceControllerV1 {
     private final SourceService sourceService;
 
     @Operation(summary = "포스트의 출처 뉴스 Top 10 조회")
+	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_1})
     @GetMapping("/posts/{postId}/news")
     public RsData<SourceListResponse> getNewsSourceList(@PathVariable("postId") Long postId) {
         List<SourceDto> sources = sourceService.getTop10NewsSourcesByPostId(postId);
@@ -39,6 +43,7 @@ public class SourceControllerV1 {
     }
 
     @Operation(summary = "포스트의 출처 영상 Top 10 조회")
+	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_1})
     @GetMapping("/posts/{postId}/videos")
     public RsData<SourceListResponse> getVideoSourceList(@PathVariable("postId") Long postId) {
         List<SourceDto> sources = sourceService.getTop10VideoSourcesByPostId(postId);
@@ -54,6 +59,7 @@ public class SourceControllerV1 {
             summary = "실시간 인기 유튜브 비디오 목록 조회 (페이지네이션)",
             description = "키워드를 통해 YouTube Data API를 호출하여 현재 한국에서 인기 있는 YouTube 비디오 목록을 가져옵니다."
     )
+	@ApiErrorCodeExamples({ErrorCode.KEYWORDS_NOT_FOUND_1})
     @GetMapping("/videos/top")
     public RsData<TopSourceListResponse> getTopYoutubeSources(
             @ParameterObject @PageableDefault(
@@ -75,6 +81,7 @@ public class SourceControllerV1 {
             summary = "실시간 인기 네이버 뉴스 목록 조회 (페이지네이션)",
             description = "키워드를 통해 네이버 뉴스 API를 호출하여 현재 한국에서 인기 있는 네이버 뉴스 목록을 가져옵니다."
     )
+	@ApiErrorCodeExamples({ErrorCode.KEYWORDS_NOT_FOUND_1})
     @GetMapping("/news/top")
     public RsData<TopSourceListResponse> getTopNaverNewsSources(
             @ParameterObject @PageableDefault(

--- a/backend/src/main/java/site/kkokkio/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SwaggerConfig.java
@@ -1,22 +1,90 @@
 package site.kkokkio.global.config;
 
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import site.kkokkio.global.dto.Empty;
+import site.kkokkio.global.dto.RsData;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
+import site.kkokkio.global.exception.doc.ExampleHolder;
 
 @Configuration
 public class SwaggerConfig {
 
-    // Swagger info 작성 (제목, 버전, 설명)
-    @Bean
-    public OpenAPI openAPI() {
-        Info info = new Info()
-                .title("꼬끼오 API")
-                .version("Ver 1.0")
-                .description("프로젝트 '꼬끼오' 서비스의 백엔드 API 명세서입니다.");
+	// Swagger info 작성 (제목, 버전, 설명)
+	@Bean
+	public OpenAPI openAPI() {
+		Info info = new Info()
+			.title("꼬끼오 API")
+			.version("Ver 1.0")
+			.description("프로젝트 '꼬끼오' 서비스의 백엔드 API 명세서입니다.");
 
-        return new OpenAPI()
-                .info(info);
-    }
+		return new OpenAPI()
+			.info(info);
+	}
+
+	// API 응답을 커스터마이징하는 메서드
+	// 특정 API에 @ApiErrorCodeExamples 어노테이션이 있는 경우, 예제 응답을 추가
+
+	@Bean
+	public OperationCustomizer customize() {
+		return (Operation operation, HandlerMethod handlerMethod) -> {
+			// 메서드에서 @ApiErrorCodeExamples 어노테이션을 가져옴
+			ApiErrorCodeExamples apiErrorCodeExamples = handlerMethod.getMethodAnnotation(ApiErrorCodeExamples.class);
+			if (apiErrorCodeExamples != null) {
+				// API 응답에 에러 예제 추가
+				addErrorExamplesToResponses(operation.getResponses(), apiErrorCodeExamples.value());
+			}
+			return operation;
+		};
+	}
+
+	// API 응답에 에러 예제들을 추가하는 메서드
+	private void addErrorExamplesToResponses(ApiResponses responses, ErrorCode[] errorCodes) {
+		Map<Integer, List<ExampleHolder>> groupedExamples = Arrays.stream(errorCodes)
+			.map(this::createExampleHolder)
+			.collect(Collectors.groupingBy(ExampleHolder::code));
+
+		groupedExamples.forEach((status, exampleHolders) -> {
+			Content content = new Content();
+			MediaType mediaType = new MediaType();
+			ApiResponse apiResponse = new ApiResponse();
+
+			// 각 ExampleHolder를 API 응답에 추가
+			exampleHolders.forEach(holder -> mediaType.addExamples(holder.name(), holder.example()));
+
+			// 응답 형식 설정, api 응답 추가
+			content.addMediaType("application/json", mediaType);
+			apiResponse.setContent(content);
+			responses.addApiResponse(String.valueOf(status), apiResponse);
+		});
+	}
+
+	// 에러 코드에 대한 예제 응답을 생성하는 메서드
+	private ExampleHolder createExampleHolder(ErrorCode errorCode) {
+		Example example = new Example();
+		example.setValue(new RsData<Empty>(errorCode.getCode(), errorCode.getMessage()));
+
+		return ExampleHolder.builder()
+			.example(example)
+			.code(Integer.parseInt(errorCode.getCode()))
+			.name(errorCode.name())
+			.build();
+	}
 }

--- a/backend/src/main/java/site/kkokkio/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SwaggerConfig.java
@@ -83,7 +83,7 @@ public class SwaggerConfig {
 
 		return ExampleHolder.builder()
 			.example(example)
-			.code(Integer.parseInt(errorCode.getCode()))
+			.code(Integer.parseInt(errorCode.getCode().split("-")[0]))
 			.name(errorCode.name())
 			.build();
 	}

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ApiErrorCodeExamples.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ApiErrorCodeExamples.java
@@ -1,0 +1,12 @@
+package site.kkokkio.global.exception.doc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+	ErrorCode[] value();
+}

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -11,13 +11,16 @@ public enum ErrorCode {
 	COMMENT_DELETE_FORBIDDEN("403", "본인 댓글만 삭제할 수 있습니다."),
 	COMMENT_LIKE_FORBIDDEN("403", "본인 댓글은 좋아요 할 수 없습니다."),
 	COMMENT_LIKE_BAD_REQUEST("400", "이미 좋아요를 누른 댓글입니다."),
-	KEYWORD_NOT_FOUND("404", "키워드를 불러오지 못했습니다."),
 	EMAIL_ALREADY_EXIST("409-1", "이미 사용중인 이메일입니다."),
+	EMAIL_NOT_FOUND("404", "존재하지 않는 이메일입니다."),
 	NICKNAME_ALREADY_EXIST("409-2", "이미 사용중인 닉네임입니다."),
 	PASSWORD_UNAUTHORIZED("401", "비밀번호가 올바르지 않습니다."),
-	POST_NOT_FOUND("404", "해당 포스트를 찾을 수 없습니다."),
+	POST_NOT_FOUND_1("404", "해당 포스트를 찾을 수 없습니다."),
+	POST_NOT_FOUND_2("404", "포스트를 불러오지 못했습니다."),
+	POST_NOT_FOUND_3("404", "존재하지 않는 포스트입니다."),
 	KEYWORD_METRIC_HOURLY_NOT_FOUND("404", "KeywordMetricHourly를 찾을 수 없습니다."),
-	KEYWORDS_NOT_FOUND("404", "Keyword를 찾을 수 없습니다."),
+	KEYWORDS_NOT_FOUND_1("404", "키워드를 불러오지 못했습니다."),
+	KEYWORDS_NOT_FOUND_2("404", "Keyword를 찾을 수 없습니다."),
 	NAVER_BAD_GATEWAY("502", "Empty response from Naver News API");
 
 	private final String code;

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -1,0 +1,25 @@
+package site.kkokkio.global.exception.doc;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+	COMMENT_NOT_FOUND("404", "존재하지 않는 댓글입니다."),
+	COMMENT_UPDATE_FORBIDDEN("403", "본인 댓글만 수정할 수 있습니다."),
+	COMMENT_DELETE_FORBIDDEN("403", "본인 댓글만 삭제할 수 있습니다."),
+	COMMENT_LIKE_FORBIDDEN("403", "본인 댓글은 좋아요 할 수 없습니다."),
+	COMMENT_LIKE_BAD_REQUEST("400", "이미 좋아요를 누른 댓글입니다."),
+	KEYWORD_NOT_FOUND("404", "키워드를 불러오지 못했습니다."),
+	EMAIL_ALREADY_EXIST("409-1", "이미 사용중인 이메일입니다."),
+	NICKNAME_ALREADY_EXIST("409-2", "이미 사용중인 닉네임입니다."),
+	PASSWORD_UNAUTHORIZED("401", "비밀번호가 올바르지 않습니다."),
+	POST_NOT_FOUND("404", "해당 포스트를 찾을 수 없습니다."),
+	KEYWORD_METRIC_HOURLY_NOT_FOUND("404", "KeywordMetricHourly를 찾을 수 없습니다."),
+	KEYWORDS_NOT_FOUND("404", "Keyword를 찾을 수 없습니다."),
+	NAVER_BAD_GATEWAY("502", "Empty response from Naver News API");
+
+	private final String code;
+	private final String message;
+}

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ExampleHolder.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ExampleHolder.java
@@ -1,0 +1,8 @@
+package site.kkokkio.global.exception.doc;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+
+@Builder
+public record ExampleHolder(Example example, int code, String name) {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       enabled: false
 
   profiles:
-    active: ${SPRING_ACTIVE_PROFILES:test}
+    active: ${SPRING_ACTIVE_PROFILES:dev}
 
   data:
     redis:


### PR DESCRIPTION
## 연관된 이슈

> #38 

## 작업 내용

> @ApiErrorCodeExamples를 추가했습니다.

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2b110267-7899-4e36-844c-5b043e7553a5)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 작성된 컨트롤러에는 ServiceException 던지신 거 확인해서 추가했습니다. 앞으로 api 작성하실 때 어노테이션 추가 부탁드립니다!
> 현재는 swagger 문서에 message가 똑같이 나오도록 ErrorCode를 추가한 상태인데 다른 방향이 나을 것 같다고 피드백 주시면 수정하겠습니다

closes #38