### PR TITLE
Feat/60 naver open api mocking

### DIFF
--- a/backend/src/main/resources/application-prd.yml
+++ b/backend/src/main/resources/application-prd.yml
@@ -12,3 +12,6 @@ logging:
   level:
     root: WARN
     org.hibernate: WARN
+
+mock:
+  enable: false

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -147,3 +147,7 @@ naver:
   client-secret: ${NAVER_CLIENT_SECRET:test-secret}
   search:
     news-path: ${NAVER_SEARCH_NEWS_PATH:/v1/search/news.json}
+
+mock:
+  enabled: true
+  news-file: naver-news-search.json

--- a/backend/src/main/resources/mock/naver-news-search.json
+++ b/backend/src/main/resources/mock/naver-news-search.json
@@ -1,0 +1,78 @@
+{
+    "lastBuildDate": "Wed, 30 Apr 2025 15:46:01 +0900",
+    "total": 6824947,
+    "start": 1,
+    "display": 10,
+    "items": [
+        {
+            "title": "개인 투자자 77%, &quot;국내 자본시장 확대 필요&quot;…방법은 투자인센티브 강...",
+            "originallink": "https://www.ggilbo.com/news/articleView.html?idxno=1087747",
+            "link": "https://www.ggilbo.com/news/articleView.html?idxno=1087747",
+            "description": "글로벌 경제 불확실성 확대에도 응답자 중 가장 많은 32.4%가 올해 투자 비중을 늘릴 자산으로 <b>주식</b>을 꼽았다. 예·적금(15.3%), 금(8.5%), 채권(5.1%), 부동산(3.4%), 가상자산(2.7%), 달러화(2.6%) 등이 그 뒤를 이었다. 강석구... ",
+            "pubDate": "Wed, 30 Apr 2025 15:44:00 +0900"
+        },
+        {
+            "title": "오늘의 로봇기업 <b>주식</b>시세(2025-04-30)",
+            "originallink": "http://www.irobotnews.com/news/articleView.html?idxno=38435",
+            "link": "http://www.irobotnews.com/news/articleView.html?idxno=38435",
+            "description": "",
+            "pubDate": "Wed, 30 Apr 2025 15:44:00 +0900"
+        },
+        {
+            "title": "대세 ETF 상품 관심 급증...'머니마켓 ETF'에 자금 쏠리나",
+            "originallink": "http://www.finomy.com/news/articleView.html?idxno=227747",
+            "link": "http://www.finomy.com/news/articleView.html?idxno=227747",
+            "description": "올해 들어 국내를 포함한 <b>주식</b>시장이 극심한 변동성을 보이면서 투자자들의 자금이 안전 자산으로... 이는 최근 <b>주식</b>시장이 높은 변동성을 보이면서 위험도가 낮지만 금리형 대비 초과수익을 받을 수 있는... ",
+            "pubDate": "Wed, 30 Apr 2025 15:44:00 +0900"
+        },
+        {
+            "title": "미래에셋자산운용, '한국판 SGOV' 美초단기국채 ETF 신규 상장",
+            "originallink": "https://www.koreaittimes.com/news/articleView.html?idxno=140925",
+            "link": "https://www.koreaittimes.com/news/articleView.html?idxno=140925",
+            "description": "<b>주식</b> 및 채권시장에 대한 불확실성으로 안전자산에 대한 투자자들의 관심이 높아지는 가운데, 'TIGER 미국초단기(3개월이하)국채 ETF'는 국내 상장 ETF 중 유일하게 미국 초단기 국채에 100% 투자한다. 미국 초단기... ",
+            "pubDate": "Wed, 30 Apr 2025 15:44:00 +0900"
+        },
+        {
+            "title": "웅진, '상조 1위' 프리드라이프 인수에 상한가(종합)",
+            "originallink": "https://www.yna.co.kr/view/AKR20250430039051008?input=1195m",
+            "link": "https://n.news.naver.com/mnews/article/001/0015362231?sid=101",
+            "description": "웅진은 전날 종속회사 WJ라이프가 상조회사 프리드라이프 지분 99.77%를 인수하는 <b>주식</b>매매계약을 체결했다고 공시했다. 프리드라이프는 작년 말 기준 선수금 2조5천600억원을 보유한 국내 상조업계 1위 기업이다.... ",
+            "pubDate": "Wed, 30 Apr 2025 15:43:00 +0900"
+        },
+        {
+            "title": "한동훈 &quot;강남3구·용산도 용적률·건폐율 완화…종부세 폐지&quot;",
+            "originallink": "https://news.einfomax.co.kr/news/articleView.html?idxno=4353842",
+            "link": "https://news.einfomax.co.kr/news/articleView.html?idxno=4353842",
+            "description": "아울러 해외 <b>주식</b> 투자자의 세금부담 완화를 위해 양도세 공제 한도를 현행 250만원에서 5천만원으로 확대하고, 손실이 났을 경우 이후 3년간 이익에서 차감할 수 있도록 '양도손실 이월공제' 제도를 도입하겠다고... ",
+            "pubDate": "Wed, 30 Apr 2025 15:42:00 +0900"
+        },
+        {
+            "title": "이엠텍, 최대주주 변경 수반 <b>주식</b> 담보제공 계약 체결",
+            "originallink": "http://www.edaily.co.kr/news/newspath.asp?newsid=04349286642141368",
+            "link": "https://n.news.naver.com/mnews/article/018/0006002231?sid=101",
+            "description": "이엠텍(091120)은 최대주주 변경을 수반한느 <b>주식</b> 담보제공 계약을 체결했다고 30일 공시했다.",
+            "pubDate": "Wed, 30 Apr 2025 15:41:00 +0900"
+        },
+        {
+            "title": "유엔젤, SKT 유심 교체 대란에 eSIM 서비스 활용 가능성에 ‘관심’",
+            "originallink": "http://www.wowtv.co.kr/NewsCenter/News/Read?articleId=A202504300595&t=NN",
+            "link": "https://n.news.naver.com/mnews/article/215/0001207786?sid=101",
+            "description": "이 같은 소식에 <b>주식</b>시장에서는 유엔젤에 매수세가 몰리며 상승하는 것으로 풀이된다. 한편 유엔젤의 최대주주가 2대 주주와 공동으로 보유 <b>주식</b> 매각 계약을 체결하면서 경영권 변동 가능성이 제기된 점도 주가에... ",
+            "pubDate": "Wed, 30 Apr 2025 15:40:00 +0900"
+        },
+        {
+            "title": "한국투자증권, 라임펀드 등 불완전판매 기관 경고…&quot;직원 대상 구상권 ...",
+            "originallink": "https://www.greened.kr/news/articleView.html?idxno=326173",
+            "link": "https://www.greened.kr/news/articleView.html?idxno=326173",
+            "description": "해당 증권사들은 문제된 대체투자가 아닌 <b>주식</b>형 라임펀드를 판매했다. 반면 대신증권의 경우 과거 라임펀드 불완전판매 건과 관련해 구상권을 청구한 바 있다. 대신증권은 라임펀드를 판매한 반포WM센터 소속 직원... ",
+            "pubDate": "Wed, 30 Apr 2025 15:40:00 +0900"
+        },
+        {
+            "title": "“서울국제도서전 공공성 회복해야”…7개 출판문화단체 연대 성명",
+            "originallink": "https://news.kbs.co.kr/news/pc/view/view.do?ncd=8242054&ref=A",
+            "link": "https://n.news.naver.com/mnews/article/056/0011942486?sid=103",
+            "description": "도서전의 <b>주식</b>회사 전환 백지화와 지분 구조 재검토, 지속 가능한 공적 지원 확대 등이 이뤄져야 한다고... 도서전을 <b>주식</b>회사로 전환했습니다. 하지만, 이 과정에서 주주명부 공개, 공청회 등 투명한 절차가 지켜지지... ",
+            "pubDate": "Wed, 30 Apr 2025 15:40:00 +0900"
+        }
+    ]
+}

--- a/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterMockTest.java
+++ b/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterMockTest.java
@@ -1,0 +1,34 @@
+package site.kkokkio.infra.naver.news;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import reactor.test.StepVerifier;
+import site.kkokkio.domain.source.dto.NewsDto;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NaverNewsApiAdapterMockTest {
+    @Autowired
+    private NaverNewsApiAdapter adapter;
+
+    @Test
+    @DisplayName("비운영환경에서 Mock JSON 파일로부터 News 가져오기 - 성공")
+    void fetchNews_mockData() {
+        StepVerifier.create(adapter.fetchNews("mock", 10, 1, "sim"))
+                    .assertNext(list -> {
+                        assertThat(list).isNotEmpty();
+                        assertThat(list.size()).isEqualTo(10);
+                        NewsDto first = list.getFirst();
+                        assertThat(first.title()).isNotBlank();
+                        assertThat(first.link()).startsWith("https://");
+                        assertThat(first.pubDate()).isNotNull();
+                    })
+                    .verifyComplete();
+    }
+}

--- a/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterTest.java
+++ b/backend/src/test/java/site/kkokkio/infra/naver/news/NaverNewsApiAdapterTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -35,6 +36,9 @@ import site.kkokkio.infra.common.exception.RetryableExternalApiException;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "mock.enabled=false"
+})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 class NaverNewsApiAdapterTest {
 


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #60 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 운영 환경을 제외한 환경에서 Naver API 호출 시 실제 데이터가 아니라 Mocking Data를 가져올 수 있도록 수정했습니다.
- Profile이 prd가 아닐 경우(=`mock.enabled` 로 관리)에 mock data가 응답합니다.
- test case를 webClient mocking과 실제 mock data 반환을 나누어 테스트하여 통과했습니다.

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #60