### PR TITLE
Feat/51 refresh token & logout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
-name: deploy-develop
+name: deploy-deploy
+#name: deploy-develop
 
 on:
   push:
@@ -9,7 +10,8 @@ on:
       - 'backend/settings.gradle'
       - 'backend/Dockerfile'
     branches:
-      - develop
+      - deploy
+#      - develop
 
 jobs:
   makeTagAndRelease:
@@ -93,9 +95,10 @@ jobs:
       - name: 인스턴스 ID 가져오기
         id: get_instance_id
         run: |
-          INSTANCE_ID=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=team04-kkokkio" "Name=instance-state-name,Values=running" --query "Reservations[].Instances[].InstanceId" --output text)
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=team04-kkokkio" "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId" --output text)
           echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
-          echo $INSTANCE_ID
 
       - name: AWS SSM Send-Command
         uses: peterkimzz/aws-ssm-send-command@master
@@ -108,9 +111,13 @@ jobs:
           working-directory: /
           comment: Deploy
           command: |
+            set -e
+            export HOME=/root
+            echo "${{ secrets.TK_GITHUB_ACCESS_TOKEN }}" | docker login ghcr.io -u ${{ secrets.TK_GITHUB_ACCESS_TOKEN_OWNER }} --password-stdin
+            
             docker pull ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
             docker stop app1 2>/dev/null || true && \
             docker rm app1 2>/dev/null || true && \
-            export DOPPLER_TOKEN=${{ secrets.DOPPLER_SERVICE_TOKEN }} && \
-            doppler run -- docker run -d --name app1 --network common -p 8080:8080 ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
+            DOPPLER_TOKEN=${{ secrets.DOPPLER_SERVICE_TOKEN }} doppler run -- docker run -d --name app1 --network common -p 8080:8080 \
+              ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
             docker rmi $(docker images -f "dangling=true" -q) || true

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
 import site.kkokkio.domain.member.dto.EmailVerificationRequest;
+import site.kkokkio.domain.member.dto.TokenResponse;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -64,6 +66,20 @@ public class MemberControllerV1 {
 		jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
 
 		return new RsData<>("200", "로그인 성공", loginResponse);
+	}
+
+	@Operation(summary = "토큰 재발급")
+	@PostMapping("/refresh")
+	public RsData<TokenResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+		TokenResponse tokenResponse = authService.refreshToken(request, response);
+		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenResponse);
+	}
+
+	@Operation(summary = "로그아웃")
+	@PostMapping("/logout")
+	public RsData<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		authService.logout(request, response);
+		return new RsData<>("200", "로그아웃 되었습니다.");
 	}
 
 	@Operation(summary = "이메일 인증 코드 전송")

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -70,6 +70,8 @@ public class MemberControllerV1 {
 
 	@Operation(summary = "토큰 재발급")
 	@PostMapping("/refresh")
+	@ApiErrorCodeExamples({ErrorCode.REFRESH_TOKEN_NOT_FOUND,
+		ErrorCode.REFRESH_TOKEN_MISMATCH, ErrorCode.REFRESH_TOKEN_INTERNAL_ERROR})
 	public RsData<TokenResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
 		TokenResponse tokenResponse = authService.refreshToken(request, response);
 		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenResponse);
@@ -77,6 +79,7 @@ public class MemberControllerV1 {
 
 	@Operation(summary = "로그아웃")
 	@PostMapping("/logout")
+	@ApiErrorCodeExamples({ErrorCode.LOGOUT_BAD_REQUEST, ErrorCode.LOGOUT_INTERNAL_SERVER_ERROR})
 	public RsData<Void> logout(HttpServletRequest request, HttpServletResponse response) {
 		authService.logout(request, response);
 		return new RsData<>("200", "로그아웃 되었습니다.");

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -14,12 +14,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
 import site.kkokkio.domain.member.controller.dto.MemberLoginRequest;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
-import site.kkokkio.domain.member.dto.EmailVerificationRequest;
-import site.kkokkio.domain.member.dto.TokenResponse;
+import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -72,9 +72,9 @@ public class MemberControllerV1 {
 	@PostMapping("/refresh")
 	@ApiErrorCodeExamples({ErrorCode.REFRESH_TOKEN_NOT_FOUND,
 		ErrorCode.REFRESH_TOKEN_MISMATCH, ErrorCode.REFRESH_TOKEN_INTERNAL_ERROR})
-	public RsData<TokenResponse> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-		TokenResponse tokenResponse = authService.refreshToken(request, response);
-		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenResponse);
+	public RsData<TokenDto> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+		TokenDto tokenDto = authService.refreshToken(request, response);
+		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenDto);
 	}
 
 	@Operation(summary = "로그아웃")

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -18,6 +18,7 @@ import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
 import site.kkokkio.domain.member.dto.EmailVerificationRequest;
+import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
 import site.kkokkio.global.dto.RsData;
@@ -32,6 +33,7 @@ import site.kkokkio.global.util.JwtUtils;
 public class MemberControllerV1 {
 
 	private final MemberService memberService;
+	private final AuthService authService;
 	private final JwtUtils jwtUtils;
 	private final MailService mailService;
 
@@ -54,10 +56,12 @@ public class MemberControllerV1 {
 	) {
 
 		// 로그인 서비스 호출
-		MemberLoginResponse loginResponse = memberService.loginMember(request.email(), request.passwordHash());
+		MemberLoginResponse loginResponse = authService.login(request.email(), request.passwordHash(), response);
 
 		// JWT 토큰 쿠키에 설정
 		jwtUtils.setJwtInCookie(loginResponse.token(), response);
+		//
+		jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
 
 		return new RsData<>("200", "로그인 성공", loginResponse);
 	}

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/dto/EmailVerificationRequest.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/dto/EmailVerificationRequest.java
@@ -1,4 +1,4 @@
-package site.kkokkio.domain.member.dto;
+package site.kkokkio.domain.member.controller.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/dto/MemberLoginResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/dto/MemberLoginResponse.java
@@ -15,10 +15,12 @@ public record MemberLoginResponse(
 	LocalDateTime deleteAt,
 	MemberRole role,
 	@JsonIgnore
-	String token
+	String token,
+	@JsonIgnore
+	String refreshToken
 ) {
-	public static MemberLoginResponse of(Member member, String token) {
+	public static MemberLoginResponse of(Member member, String token, String refreshToken) {
 		return new MemberLoginResponse(member.getNickname(), member.getEmail(),
-			member.getDeletedAt(), member.getRole(), token);
+			member.getDeletedAt(), member.getRole(), token, refreshToken);
 	}
 }

--- a/backend/src/main/java/site/kkokkio/domain/member/dto/TokenDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/dto/TokenDto.java
@@ -1,0 +1,4 @@
+package site.kkokkio.domain.member.dto;
+
+public record TokenDto(String accessToken, String refreshToken) {
+}

--- a/backend/src/main/java/site/kkokkio/domain/member/dto/TokenResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/dto/TokenResponse.java
@@ -1,4 +1,0 @@
-package site.kkokkio.domain.member.dto;
-
-public record TokenResponse(String accessToken, String refreshToken) {
-}

--- a/backend/src/main/java/site/kkokkio/domain/member/dto/TokenResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package site.kkokkio.domain.member.dto;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+}

--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -63,7 +63,7 @@ public class AuthService {
 	@Transactional
 	public TokenResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
 		String rt = jwtUtils.getRefreshTokenFromCookies(request)
-			.orElseThrow(() -> new ServiceException("401", "리프레시 토큰이 없습니다."));
+			.orElseThrow(() -> new ServiceException("401-1", "리프레시 토큰이 없습니다."));
 
 		// 페이로드에서 이메일 추출
 		String email = jwtUtils.getPayload(rt).get("email", String.class);
@@ -71,7 +71,7 @@ public class AuthService {
 		// Redis에 저장된 RT와 비교
 		String savedRt = redisTemplate.opsForValue().get("RT:" + email);
 		if (savedRt == null || !savedRt.equals(rt)) {
-			throw new ServiceException("401", "유효하지 않은 리프레시 토큰입니다.");
+			throw new ServiceException("401-2", "유효하지 않은 리프레시 토큰입니다.");
 		}
 
 		// 새로운 토큰 발급
@@ -87,7 +87,7 @@ public class AuthService {
 	/** 로그아웃 -> Access Token 블랙리스트 등록 + Refresh Token 삭제 + 쿠키 삭제 */
 	public void logout(HttpServletRequest request, HttpServletResponse response) {
 		String at = jwtUtils.getJwtFromCookies(request)
-			.orElseThrow(() -> new ServiceException("401", "액세스 토큰이 없습니다."));
+			.orElseThrow(() -> new ServiceException("401", "로그인 상태가 아닙니다."));
 
 		String email = jwtUtils.getPayload(at).get("email", String.class);
 

--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -13,7 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
-import site.kkokkio.domain.member.dto.TokenResponse;
+import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.global.util.JwtUtils;
@@ -61,7 +61,7 @@ public class AuthService {
 
 	/** Refresh Token 검증 후 Access/Refresh 재발급 + Redis 갱신 + 쿠키 업데이트 */
 	@Transactional
-	public TokenResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
+	public TokenDto refreshToken(HttpServletRequest request, HttpServletResponse response) {
 		String rt = jwtUtils.getRefreshTokenFromCookies(request)
 			.orElseThrow(() -> new ServiceException("401-1", "리프레시 토큰이 없습니다."));
 
@@ -81,7 +81,7 @@ public class AuthService {
 		// 쿠키에도 업데이트
 		jwtUtils.setJwtInCookie(newAt, response);
 
-		return new TokenResponse(newAt, rt);
+		return new TokenDto(newAt, rt);
 	}
 
 	/** 로그아웃 -> Access Token 블랙리스트 등록 + Refresh Token 삭제 + 쿠키 삭제 */

--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -1,0 +1,105 @@
+package site.kkokkio.domain.member.service;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
+import site.kkokkio.domain.member.dto.TokenResponse;
+import site.kkokkio.domain.member.entity.Member;
+import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.util.JwtUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final MemberService memberService;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtils jwtUtils;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	/** 로그인 -> Access/Refresh 토큰 생성 + Redis 저장 + 쿠키 세팅 */
+	@Transactional
+	public MemberLoginResponse login(String email, String rawPassword, HttpServletResponse response) {
+		Member member = memberService.findByEmail(email);
+
+		// 비밀번호 확인
+		if (!passwordEncoder.matches(rawPassword, member.getPasswordHash())) {
+			throw new ServiceException("401", "비밀번호가 올바르지 않습니다.");
+		}
+
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("id", member.getId());
+		claims.put("email", member.getEmail());
+		claims.put("nickname", member.getNickname());
+		claims.put("role", member.getRole());
+
+		// token, refreshToken 생성
+		String accessToken = jwtUtils.createToken(claims);
+		String refreshToken = jwtUtils.createRefreshToken(claims);
+
+		// Redis에 Refresh Token 저장 (키: "RT:<email>")
+		Duration rtTtl = Duration.ofMillis(jwtUtils.getRefreshTokenExpiration());
+		redisTemplate.opsForValue()
+			.set("RT:" + member.getEmail(), refreshToken, rtTtl);
+
+		// 쿠키에 토큰 세팅
+		jwtUtils.setJwtInCookie(accessToken, response);
+		jwtUtils.setRefreshTokenInCookie(refreshToken, response);
+
+		return MemberLoginResponse.of(member, accessToken, refreshToken);
+	}
+
+	/** Refresh Token 검증 후 Access/Refresh 재발급 + Redis 갱신 + 쿠키 업데이트 */
+	@Transactional
+	public TokenResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
+		String rt = jwtUtils.getRefreshTokenFromCookies(request)
+			.orElseThrow(() -> new ServiceException("401", "리프레시 토큰이 없습니다."));
+
+		// 페이로드에서 이메일 추출
+		String email = jwtUtils.getPayload(rt).get("email", String.class);
+
+		// Redis에 저장된 RT와 비교
+		String savedRt = redisTemplate.opsForValue().get("RT:" + email);
+		if (savedRt == null || !savedRt.equals(rt)) {
+			throw new ServiceException("401", "유효하지 않은 리프레시 토큰입니다.");
+		}
+
+		// 새로운 토큰 발급
+		Map<String, Object> claims = jwtUtils.getPayload(rt);
+		String newAt = jwtUtils.createToken(claims);
+
+		// 쿠키에도 업데이트
+		jwtUtils.setJwtInCookie(newAt, response);
+
+		return new TokenResponse(newAt, rt);
+	}
+
+	/** 로그아웃 -> Access Token 블랙리스트 등록 + Refresh Token 삭제 + 쿠키 삭제 */
+	public void logout(HttpServletRequest request, HttpServletResponse response) {
+		String at = jwtUtils.getJwtFromCookies(request)
+			.orElseThrow(() -> new ServiceException("401", "액세스 토큰이 없습니다."));
+
+		String email = jwtUtils.getPayload(at).get("email", String.class);
+
+		// Access Token 남은 만료시간 만큼 블랙리스트에 저장
+		long remainingMs = jwtUtils.getExpiration(at).getTime() - System.currentTimeMillis();
+		redisTemplate.opsForValue()
+			.set("BL:" + at, "logout", Duration.ofMillis(remainingMs));
+
+		// Redis에서 Refresh Token 삭제
+		redisTemplate.delete("RT:" + email);
+
+		// 쿠키 삭제
+		jwtUtils.clearAuthCookies(response);
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/member/service/MailService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/MailService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
-import site.kkokkio.domain.member.dto.EmailVerificationRequest;
+import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.domain.member.repository.MemberRepository;
 import site.kkokkio.global.exception.ServiceException;

--- a/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
@@ -1,14 +1,10 @@
 package site.kkokkio.domain.member.service;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
 import site.kkokkio.domain.member.entity.Member;
@@ -52,26 +48,35 @@ public class MemberService {
 		return new MemberResponse(member);
 	}
 
-	// 로그인
-	public MemberLoginResponse loginMember(String email, String password) {
-
-		// 회원 이메일 확인
-		Member member = memberRepository.findByEmail(email).orElseThrow(() ->
-			new ServiceException("404", "존재하지 않는 이메일입니다."));
-
-		// 비밀번호 확인
-		if (!passwordEncoder.matches(password, member.getPasswordHash())) {
-			throw new ServiceException("401", "비밀번호가 올바르지 않습니다.");
-		}
-
-		// JWT 토큰 발생 시 포함할 사용자 정보 설정
-		Map<String, Object> claims = new HashMap<>();
-		claims.put("id", member.getId());
-		claims.put("email", member.getEmail());
-		claims.put("nickname", member.getNickname());
-		claims.put("role", member.getRole());
-		String token = jwtUtils.createToken(claims); // 토큰 생성
-
-		return MemberLoginResponse.of(member, token);
+	// 이메일로 회원 조회
+	// (로그인, 토큰 재발급 등에서 사용)
+	public Member findByEmail(String email) {
+		return memberRepository.findByEmail(email)
+			.orElseThrow(() -> new ServiceException("404", "존재하지 않는 이메일입니다."));
 	}
+
+	// // 로그인
+	// public MemberLoginResponse loginMember(String email, String password) {
+	//
+	// 	// 회원 이메일 확인
+	// 	Member member = memberRepository.findByEmail(email).orElseThrow(() ->
+	// 		new ServiceException("404", "존재하지 않는 이메일입니다."));
+	//
+	// 	// 비밀번호 확인
+	// 	if (!passwordEncoder.matches(password, member.getPasswordHash())) {
+	// 		throw new ServiceException("401", "비밀번호가 올바르지 않습니다.");
+	// 	}
+	//
+	// 	// JWT 토큰 발생 시 포함할 사용자 정보 설정
+	// 	Map<String, Object> claims = new HashMap<>();
+	// 	claims.put("id", member.getId());
+	// 	claims.put("email", member.getEmail());
+	// 	claims.put("nickname", member.getNickname());
+	// 	claims.put("role", member.getRole());
+	// 	String token = jwtUtils.createToken(claims); // 토큰 생성
+	//
+	// 	return MemberLoginResponse.of(member, token,);
+	// }
+
+	// 토큰 갱신
 }

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -6,6 +6,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+	LOGOUT_BAD_REQUEST("401", "로그인 상태가 아닙니다."),
+	LOGOUT_INTERNAL_SERVER_ERROR("500", "비밀번호가 올바르지 않습니다."),
+	REFRESH_TOKEN_NOT_FOUND("401-1", "리프레시 토큰이 없습니다."),
+	REFRESH_TOKEN_MISMATCH("401-2", "유효하지 않은 리프레시 토큰입니다."),
+	REFRESH_TOKEN_INTERNAL_ERROR("500", "리프레시 토큰 처리 중 서버 오류가 발생했습니다."),
 	COMMENT_NOT_FOUND("404", "존재하지 않는 댓글입니다."),
 	COMMENT_UPDATE_FORBIDDEN("403", "본인 댓글만 수정할 수 있습니다."),
 	COMMENT_DELETE_FORBIDDEN("403", "본인 댓글만 삭제할 수 있습니다."),

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -37,8 +37,32 @@ public class JwtUtils {
 	@Value("${spring.jwt.expiration}")
 	private Long expiration;// dev 환경 10분
 
-	@Value("${spring.jwt.refresh-expiration}")
-	private Long refreshTokenExpiration;
+	private final Long refreshTokenExpiration = 7 * 24 * 60 * 60 * 1000L; // 리프레시 토큰 만료일 7일
+
+	// token 만료 시간 반환
+	public long getAccessTokenExpiration() {
+		return expiration;
+	}
+
+	public Date getExpiration(String token) {
+		try {
+			SecretKey key = getSecretKey();
+			return Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload()
+				.getExpiration();
+		} catch (JwtException | IllegalArgumentException e) {
+			handleAuthException(e);
+			throw e; // 위에서 예외 처리하므로 실질적으로 실행되지 않음 (명시용)
+		}
+	}
+
+	// Refresh Token 만료 시간 반환
+	public long getRefreshTokenExpiration() {
+		return refreshTokenExpiration;
+	}
 
 	// JWT 생성
 	public String createToken(Map<String, Object> claims) {
@@ -103,7 +127,7 @@ public class JwtUtils {
 			.httpOnly(true) // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/") // 전체 사이트에서 접근 가능
 			.sameSite("None") // 외부 사이트 요청 차단 (CSRF 방지)
-			.maxAge(Duration.ofDays(1)) // Access Token 만료 시간
+			.maxAge(Duration.ofMinutes(10)) // Access Token 만료 시간 : 10분
 			.secure(true) // HTTPS 통신 시에만 전송
 			.build();
 
@@ -117,7 +141,7 @@ public class JwtUtils {
 			.httpOnly(true)     // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/auth")      // 인증 경로에서만 접근 가능
 			.sameSite("None")   // 외부 사이트 요청 허용 (CORS 환경 대응)
-			.maxAge(Duration.ofMillis(refreshTokenExpiration)) // Refresh Token 만료 시간
+			.maxAge(Duration.ofMillis(refreshTokenExpiration)) // Refresh Token 만료 시간 : 7일
 			.secure(true)       // HTTPS 통신 시에만 전송
 			.build();
 
@@ -156,7 +180,6 @@ public class JwtUtils {
 			.findFirst();
 	}
 
-	// 쿠키 삭제(로그아웃)
 	// 쿠키 삭제 (로그아웃 시 사용)
 	public void clearAuthCookies(HttpServletResponse response) {
 		// 액세스 토큰 쿠키 삭제
@@ -181,6 +204,7 @@ public class JwtUtils {
 		response.addHeader("Set-Cookie", refreshCookie.toString());
 	}
 
+	// 시크릿 키 생성
 	private SecretKey getSecretKey() {
 		SecretKey key = Keys.hmacShaKeyFor(HexFormat.of().parseHex(secretKey)); // 16진수 문자열 → 바이트 배열
 		return key;

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -123,7 +123,7 @@ public class JwtUtils {
 
 	//JWT -> 쿠키에 저장
 	public void setJwtInCookie(String token, HttpServletResponse response) {
-		ResponseCookie cookie = ResponseCookie.from("token", token)
+		ResponseCookie cookie = ResponseCookie.from("access-token", token)
 			.httpOnly(true) // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/") // 전체 사이트에서 접근 가능
 			.sameSite("None") // 외부 사이트 요청 차단 (CSRF 방지)
@@ -161,7 +161,7 @@ public class JwtUtils {
 			.forEach(cookie -> log.info("Cookie Name: {}, Value: {}", cookie.getName(), cookie.getValue()));
 
 		return Arrays.stream(cookies)
-			.filter(cookie -> "token".equals(cookie.getName()))
+			.filter(cookie -> "access-token".equals(cookie.getName()))
 			.map(Cookie::getValue)
 			.findFirst();
 	}
@@ -183,7 +183,7 @@ public class JwtUtils {
 	// 쿠키 삭제 (로그아웃 시 사용)
 	public void clearAuthCookies(HttpServletResponse response) {
 		// 액세스 토큰 쿠키 삭제
-		ResponseCookie accessCookie = ResponseCookie.from("token", "")
+		ResponseCookie accessCookie = ResponseCookie.from("access-token", "")
 			.httpOnly(true)
 			.path("/")
 			.maxAge(0) // 즉시 만료

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -127,7 +127,7 @@ public class JwtUtils {
 			.httpOnly(true) // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/") // 전체 사이트에서 접근 가능
 			.sameSite("None") // 외부 사이트 요청 차단 (CSRF 방지)
-			.maxAge(Duration.ofMinutes(10)) // Access Token 만료 시간 : 10분
+			.maxAge(Duration.ofMillis(expiration)) // Access Token 만료 시간 : 10분
 			.secure(true) // HTTPS 통신 시에만 전송
 			.build();
 

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -183,7 +183,7 @@ public class JwtUtils {
 	// 쿠키 삭제 (로그아웃 시 사용)
 	public void clearAuthCookies(HttpServletResponse response) {
 		// 액세스 토큰 쿠키 삭제
-		ResponseCookie accessCookie = ResponseCookie.from("access_token", "")
+		ResponseCookie accessCookie = ResponseCookie.from("token", "")
 			.httpOnly(true)
 			.path("/")
 			.maxAge(0) // 즉시 만료

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
@@ -23,7 +23,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
-import site.kkokkio.domain.member.dto.TokenResponse;
+import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -151,10 +151,10 @@ class MemberControllerV1Test {
 	@DisplayName("토큰 재발급 - 성공")
 	void refreshTokenSuccess() throws Exception {
 		// given
-		TokenResponse tokenResponse = new TokenResponse("newAccessToken", "existingRefreshToken");
+		TokenDto tokenDto = new TokenDto("newAccessToken", "existingRefreshToken");
 
 		given(authService.refreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
-			.willReturn(tokenResponse);
+			.willReturn(tokenDto);
 
 		// when & then
 		mockMvc.perform(post("/api/v1/auth/refresh"))

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +33,7 @@ import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.global.util.JwtUtils;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AuthServiceV1Test {
 
 	@InjectMocks
@@ -60,7 +63,7 @@ class AuthServiceV1Test {
 	@BeforeEach
 	void setUp() {
 		// RedisTemplate의 opsForValue()가 반환할 mock 설정
-		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+		lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
 	}
 
@@ -162,8 +165,7 @@ class AuthServiceV1Test {
 
 		willDoNothing().given(valueOperations)
 			.set(eq("BL:" + at), eq("logout"), any(Duration.class));
-
-		willDoNothing().given(redisTemplate).delete("RT:" + email);
+		given(redisTemplate.delete("RT:" + email)).willReturn(true);
 		willDoNothing().given(jwtUtils).clearAuthCookies(response);
 
 		// when & then

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -26,7 +26,7 @@ import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
-import site.kkokkio.domain.member.dto.TokenResponse;
+import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.enums.MemberRole;
 import site.kkokkio.global.exception.ServiceException;
@@ -144,7 +144,7 @@ class AuthServiceV1Test {
 		given(valueOperations.get("RT:" + email)).willReturn(rt);
 		given(jwtUtils.createToken(claims)).willReturn("new-access");
 
-		TokenResponse result = authService.refreshToken(request, response);
+		TokenDto result = authService.refreshToken(request, response);
 
 		assertThat(result.accessToken()).isEqualTo("new-access");
 		assertThat(result.refreshToken()).isEqualTo(rt);

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -1,0 +1,173 @@
+package site.kkokkio.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
+import site.kkokkio.domain.member.dto.TokenResponse;
+import site.kkokkio.domain.member.entity.Member;
+import site.kkokkio.global.enums.MemberRole;
+import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.util.JwtUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceV1Test {
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Mock
+	private MemberService memberService;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private JwtUtils jwtUtils;
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@BeforeEach
+	void setUp() {
+		// RedisTemplate의 opsForValue()가 반환할 mock 설정
+		given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+	}
+
+	@Test
+	@DisplayName("로그인 성공")
+	void login_success() {
+		String email = "user@example.com";
+		String rawPw = "plain";
+		String encPw = "encoded";
+
+		Member member = Member.builder()
+			.email(email)
+			.passwordHash(encPw)
+			.nickname("nick")
+			.role(MemberRole.USER)
+			.build();
+
+		// Redis TTL
+		Duration rtTtl = Duration.ofMinutes(5);
+
+		// Claims
+		Map<String, Object> claims = Map.of(
+			"id", UUID.randomUUID(),
+			"email", email,
+			"nickname", "nick",
+			"role", MemberRole.USER
+		);
+
+		// given
+		given(memberService.findByEmail(email)).willReturn(member);
+		given(passwordEncoder.matches(rawPw, encPw)).willReturn(true);
+		given(jwtUtils.createToken(anyMap())).willReturn("access-token");
+		given(jwtUtils.createRefreshToken(anyMap())).willReturn("refresh-token");
+		willDoNothing().given(valueOperations)
+			.set(eq("RT:" + email), eq("refresh-token"), any(Duration.class));
+
+		// 쿠키 저장 stub
+		willDoNothing().given(jwtUtils).setJwtInCookie(eq("access-token"), any());
+		willDoNothing().given(jwtUtils).setRefreshTokenInCookie(eq("refresh-token"), any());
+
+		// when
+		// when
+		MemberLoginResponse result = authService.login(email, rawPw, response);
+
+		// then
+		assertThat(result.email()).isEqualTo(email);
+		assertThat(result.token()).isEqualTo("access-token");
+		assertThat(result.refreshToken()).isEqualTo("refresh-token");
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 비밀번호 틀림")
+	void login_fail_passwordMismatch() {
+		Member member = Member.builder()
+			.email("user@example.com")
+			.passwordHash("encoded")
+			.build();
+
+		given(memberService.findByEmail("user@example.com")).willReturn(member);
+		given(passwordEncoder.matches("wrong", "encoded")).willReturn(false);
+
+		assertThatThrownBy(() -> authService.login("user@example.com", "wrong", response))
+			.isInstanceOf(ServiceException.class)
+			.hasMessageContaining("비밀번호가 올바르지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 성공")
+	void refreshToken_success() {
+		String email = "user@example.com";
+		String rt = "refresh-token";
+
+		Claims claims = mock(Claims.class);
+		given(claims.get("email", String.class)).willReturn(email);
+
+		given(jwtUtils.getRefreshTokenFromCookies(request)).willReturn(Optional.of(rt));
+		given(jwtUtils.getPayload(rt)).willReturn(claims);
+		given(valueOperations.get("RT:" + email)).willReturn(rt);
+		given(jwtUtils.createToken(claims)).willReturn("new-access");
+
+		TokenResponse result = authService.refreshToken(request, response);
+
+		assertThat(result.accessToken()).isEqualTo("new-access");
+		assertThat(result.refreshToken()).isEqualTo(rt);
+	}
+
+	@Test
+	@DisplayName("로그아웃 성공")
+	void logout_success() {
+		String at = "access-token";
+		String email = "user@example.com";
+
+		Claims claims = mock(Claims.class);
+		given(claims.get("email", String.class)).willReturn(email);
+
+		given(jwtUtils.getJwtFromCookies(request)).willReturn(Optional.of(at));
+		given(jwtUtils.getPayload(at)).willReturn(claims);
+		given(jwtUtils.getExpiration(at)).willReturn(new Date(System.currentTimeMillis() + 60000));
+
+		willDoNothing().given(valueOperations)
+			.set(eq("BL:" + at), eq("logout"), any(Duration.class));
+
+		willDoNothing().given(redisTemplate).delete("RT:" + email);
+		willDoNothing().given(jwtUtils).clearAuthCookies(response);
+
+		// when & then
+		assertThatCode(() -> authService.logout(request, response)).doesNotThrowAnyException();
+	}
+
+}

--- a/backend/src/test/java/site/kkokkio/domain/member/service/MailServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/MailServiceTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
-import site.kkokkio.domain.member.dto.EmailVerificationRequest;
+import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.domain.member.repository.MemberRepository;
 

--- a/backend/src/test/java/site/kkokkio/domain/member/service/MemberServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/MemberServiceV1Test.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,12 +14,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.domain.member.repository.MemberRepository;
-import site.kkokkio.global.enums.MemberRole;
 import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.global.util.JwtUtils;
 
@@ -39,33 +36,22 @@ class MemberServiceV1Test {
 	@Mock
 	private JwtUtils jwtUtils;
 
-	//--- 회원 가입 테스트 ----------------------------------
-
 	@Test
-	@DisplayName("회원 가입 성공")
+	@DisplayName("회원가입 성공")
 	void createMember_success() {
 		// given
-		UUID id = UUID.randomUUID();
 		String email = "user@example.com";
-		String rawPassword = "plaintext";
-		String nickname = "usernick";
+		String nickname = "tester";
 		LocalDate birthDate = LocalDate.of(1990, 1, 1);
+		String rawPassword = "pw";
+		String encPassword = "hashed-pw";
 
 		MemberSignUpRequest request = new MemberSignUpRequest(email, rawPassword, nickname, birthDate);
 
 		given(memberRepository.existsByEmail(email)).willReturn(false);
 		given(memberRepository.existsByNickname(nickname)).willReturn(false);
-		given(passwordEncoder.encode(rawPassword)).willReturn("encryptedPwd");
-
-		Member saved = Member.builder()
-			.id(id)
-			.email(email)
-			.passwordHash("encryptedPwd")
-			.nickname(nickname)
-			.birthDate(birthDate)
-			.role(MemberRole.USER)
-			.build();
-		given(memberRepository.save(any(Member.class))).willReturn(saved);
+		given(passwordEncoder.encode(rawPassword)).willReturn(encPassword);
+		given(memberRepository.save(any(Member.class))).willAnswer(inv -> inv.getArgument(0));
 
 		// when
 		MemberResponse response = memberService.createMember(request);
@@ -73,102 +59,53 @@ class MemberServiceV1Test {
 		// then
 		assertThat(response.getEmail()).isEqualTo(email);
 		assertThat(response.getNickname()).isEqualTo(nickname);
-		assertThat(response.getBirthDate()).isEqualTo(birthDate);
-		assertThat(response.getRole()).isEqualTo(MemberRole.USER);
 	}
 
 	@Test
-	@DisplayName("회원 가입 실패 - 이메일 중복")
+	@DisplayName("이메일 중복 시 회원가입 실패")
 	void createMember_fail_duplicateEmail() {
-		// given
 		given(memberRepository.existsByEmail("dup@example.com")).willReturn(true);
 
-		// when & then
-		ServiceException ex = catchThrowableOfType(
-			() -> memberService.createMember(
-				new MemberSignUpRequest("dup@example.com", "pw", "nick", LocalDate.now())),
-			ServiceException.class);
-
-		assertThat(ex.getCode()).isEqualTo("409-1");
-		assertThat(ex.getMessage()).contains("이미 사용중인 이메일입니다.");
+		assertThatThrownBy(() -> memberService.createMember(
+			new MemberSignUpRequest("dup@example.com", "pw", "nick", LocalDate.now())))
+			.isInstanceOf(ServiceException.class)
+			.hasMessageContaining("이미 사용중인 이메일");
 	}
 
 	@Test
-	@DisplayName("회원 가입 실패 - 닉네임 중복")
+	@DisplayName("닉네임 중복 시 회원가입 실패")
 	void createMember_fail_duplicateNickname() {
-		// given
-		String email = "user2@example.com";
-		String nickname = "dupnick";
-		given(memberRepository.existsByEmail(email)).willReturn(false);
-		given(memberRepository.existsByNickname(nickname)).willReturn(true);
+		given(memberRepository.existsByEmail("email@example.com")).willReturn(false);
+		given(memberRepository.existsByNickname("dupNick")).willReturn(true);
 
-		// when & then
-		ServiceException ex = catchThrowableOfType(
-			() -> memberService.createMember(
-				new MemberSignUpRequest(email, "pw", nickname, LocalDate.now())),
-			ServiceException.class);
-
-		assertThat(ex.getCode()).isEqualTo("409-2");
-		assertThat(ex.getMessage()).contains("이미 사용중인 닉네임입니다.");
+		assertThatThrownBy(() -> memberService.createMember(
+			new MemberSignUpRequest("email@example.com", "pw", "dupNick", LocalDate.now())))
+			.isInstanceOf(ServiceException.class)
+			.hasMessageContaining("이미 사용중인 닉네임");
 	}
 
-	//--- 로그인 테스트 --------------------------------------
-
 	@Test
-	@DisplayName("로그인 성공")
-	void loginMember_success() {
-		// given
-		String email = "login@example.com";
-		String rawPassword = "secret";
+	@DisplayName("이메일로 회원 조회 - 성공")
+	void findByEmail_success() {
 		Member member = Member.builder()
-			.id(UUID.randomUUID())
-			.email(email)
-			.passwordHash("encoded")
+			.email("find@test.com")
 			.nickname("nick")
-			.role(MemberRole.USER)
 			.build();
 
-		given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
-		given(passwordEncoder.matches(rawPassword, member.getPasswordHash())).willReturn(true);
-		given(jwtUtils.createToken(anyMap())).willReturn("jwt-token");
+		given(memberRepository.findByEmail("find@test.com")).willReturn(Optional.of(member));
 
-		// when
-		MemberLoginResponse loginResp = memberService.loginMember(email, rawPassword);
+		Member found = memberService.findByEmail("find@test.com");
 
-		// then
-		assertThat(loginResp.email()).isEqualTo(email);
-		assertThat(loginResp.nickname()).isEqualTo("nick");
-		assertThat(loginResp.token()).isEqualTo("jwt-token");
+		assertThat(found.getEmail()).isEqualTo("find@test.com");
 	}
 
 	@Test
-	@DisplayName("로그인 실패 - 이메일 없음")
-	void loginMember_fail_notFoundEmail() {
-		// given
-		given(memberRepository.findByEmail("nope@example.com")).willReturn(Optional.empty());
+	@DisplayName("이메일로 회원 조회 - 실패")
+	void findByEmail_fail() {
+		given(memberRepository.findByEmail("notfound@test.com")).willReturn(Optional.empty());
 
-		// when & then
-		assertThatThrownBy(() -> memberService.loginMember("nope@example.com", "any"))
+		assertThatThrownBy(() -> memberService.findByEmail("notfound@test.com"))
 			.isInstanceOf(ServiceException.class)
-			.hasMessageContaining("존재하지 않는 이메일입니다.");
-	}
-
-	@Test
-	@DisplayName("로그인 실패 - 비밀번호 불일치")
-	void loginMember_fail_badPassword() {
-		// given
-		String email = "user@example.com";
-		Member member = Member.builder()
-			.email(email)
-			.passwordHash("hash")
-			.build();
-
-		given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
-		given(passwordEncoder.matches("wrong", member.getPasswordHash())).willReturn(false);
-
-		// when & then
-		assertThatThrownBy(() -> memberService.loginMember(email, "wrong"))
-			.isInstanceOf(ServiceException.class)
-			.hasMessageContaining("비밀번호가 올바르지 않습니다.");
+			.hasMessageContaining("존재하지 않는 이메일");
 	}
 }


### PR DESCRIPTION
## 연관된 이슈

> #51 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 회원과 인증 서비스 로직 분리(유지보수 유리)
- 로그인시 access토큰과 refresh토큰 발행하도록 구현
- 로그아웃시 access 토큰과 refresh 토큰 삭제하도록 구현
- access토큰과 refresh토큰은 로그인시 쿠키 세팅
- redis에서 RT:<email>로 Refresh_Token관리

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- 토큰은 email을 key값으로 관리하고 있습니다.
closes #51