### PR TITLE
feat: baseInitData 회원 입력 & SecurityConfig 설정 & 프론트URL(임시)설정

### DIFF
--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -55,28 +56,28 @@ public class SecurityConfig {
 
 			// 엔드포인트별 권한 설정
 			.authorizeHttpRequests(authorize ->
-				authorize
-					// // POST 요청에 대해 인증 없이 접근 허용
-					// .requestMatchers(
-					// 	HttpMethod.POST,
-					// 	getPublicPostEndpoints().toArray(String[]::new)
-					// ).permitAll()
-					//
-					// // GET 요청에 대해 인증 없이 접근 허용
-					// .requestMatchers(
-					// 	HttpMethod.GET,
-					// 	getPublicGetEndpoints().toArray(String[]::new)
-					// ).permitAll()
-					//
-					// // 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
-					// .requestMatchers(getPublicEndpoints().toArray(String[]::new)
-					// ).permitAll()
-					//
-					// // 그 외 모든 요청은 인증 된 사용자 필요
-					// .anyRequest().hasAnyRole("USER", "ADMIN")
+					authorize
+						// POST 요청에 대해 인증 없이 접근 허용
+						.requestMatchers(
+							HttpMethod.POST,
+							getPublicPostEndpoints().toArray(String[]::new)
+						).permitAll()
 
-					// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
-					.anyRequest().permitAll()
+						// GET 요청에 대해 인증 없이 접근 허용
+						.requestMatchers(
+							HttpMethod.GET,
+							getPublicGetEndpoints().toArray(String[]::new)
+						).permitAll()
+
+						// 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
+						.requestMatchers(getPublicEndpoints().toArray(String[]::new)
+						).permitAll()
+
+						// 그 외 모든 요청은 인증 된 사용자 필요
+						.anyRequest().hasAnyRole("USER", "ADMIN")
+
+				// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
+				// .anyRequest().permitAll()
 
 			);
 

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig {
 			"https://api.deploy.kkokkio.site" // 백엔드 API URL
 		)); // 프론트 사이트 추가
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용 HTTP 메소드
-		configuration.setAllowedHeaders(Arrays.asList("*")); // HTTP 헤더(모두 허용)
+		// configuration.setAllowedHeaders(Arrays.asList("*")); // HTTP 헤더(모두 허용)
 		configuration.setAllowCredentials(true); // 쿠키 등 자격 증명
 		// 클라이언트 노출 헤더
 		configuration.setAllowedHeaders(List.of(

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -56,28 +55,28 @@ public class SecurityConfig {
 
 			// 엔드포인트별 권한 설정
 			.authorizeHttpRequests(authorize ->
-					authorize
-						// POST 요청에 대해 인증 없이 접근 허용
-						.requestMatchers(
-							HttpMethod.POST,
-							getPublicPostEndpoints().toArray(String[]::new)
-						).permitAll()
+				authorize
+					// POST 요청에 대해 인증 없이 접근 허용
+					// .requestMatchers(
+					// 	HttpMethod.POST,
+					// 	getPublicPostEndpoints().toArray(String[]::new)
+					// ).permitAll()
+					//
+					// // GET 요청에 대해 인증 없이 접근 허용
+					// .requestMatchers(
+					// 	HttpMethod.GET,
+					// 	getPublicGetEndpoints().toArray(String[]::new)
+					// ).permitAll()
+					//
+					// // 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
+					// .requestMatchers(getPublicEndpoints().toArray(String[]::new)
+					// ).permitAll()
+					//
+					// // 그 외 모든 요청은 인증 된 사용자 필요
+					// .anyRequest().hasAnyRole("USER", "ADMIN")
 
-						// GET 요청에 대해 인증 없이 접근 허용
-						.requestMatchers(
-							HttpMethod.GET,
-							getPublicGetEndpoints().toArray(String[]::new)
-						).permitAll()
-
-						// 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
-						.requestMatchers(getPublicEndpoints().toArray(String[]::new)
-						).permitAll()
-
-						// 그 외 모든 요청은 인증 된 사용자 필요
-						.anyRequest().hasAnyRole("USER", "ADMIN")
-
-				// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
-				// .anyRequest().permitAll()
+					// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
+					.anyRequest().permitAll()
 
 			);
 

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -33,6 +34,7 @@ public class SecurityConfig {
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
 		http
 			// CORS 설정 추가
 			.cors(
@@ -56,28 +58,21 @@ public class SecurityConfig {
 			// 엔드포인트별 권한 설정
 			.authorizeHttpRequests(authorize ->
 				authorize
-					// POST 요청에 대해 인증 없이 접근 허용
-					// .requestMatchers(
-					// 	HttpMethod.POST,
-					// 	getPublicPostEndpoints().toArray(String[]::new)
-					// ).permitAll()
-					//
-					// // GET 요청에 대해 인증 없이 접근 허용
-					// .requestMatchers(
-					// 	HttpMethod.GET,
-					// 	getPublicGetEndpoints().toArray(String[]::new)
-					// ).permitAll()
-					//
-					// // 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
-					// .requestMatchers(getPublicEndpoints().toArray(String[]::new)
-					// ).permitAll()
-					//
-					// // 그 외 모든 요청은 인증 된 사용자 필요
-					// .anyRequest().hasAnyRole("USER", "ADMIN")
+					// 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
+					.requestMatchers(getPublicEndpoints().toArray(String[]::new)
+					).permitAll()
 
-					// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
+					// 댓글 GET 요청 허용
+					.requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments")
+					.permitAll()
+
+					// 회원 권한
+					.requestMatchers(getPubliCUserEndpoints().toArray(String[]::new)).hasRole("USER")
+					// 관리자 권한
+					.requestMatchers(getPublicAdminEndpoints().toArray(String[]::new)).hasRole("ADMIN")
+
+					// 그 외 모든 요청 허용
 					.anyRequest().permitAll()
-
 			);
 
 		return http.build();
@@ -133,11 +128,17 @@ public class SecurityConfig {
 		return new BCryptPasswordEncoder();
 	}
 
+	// 모든 사용자
 	private List<String> getPublicEndpoints() {
 		return List.of(
 
+			// root권한
+			"/",
+
 			// 로그인, 회원가입 등
 			"/api/v1/auth/**",
+
+			// Todo: 아래 엔드포인트는 개발 환경에서만, 운영 서버 반영 전 제거 필요
 
 			// Swagger UI 관련 경로 허용
 			"/swagger-ui/**",
@@ -153,15 +154,23 @@ public class SecurityConfig {
 		);
 	}
 
-	private List<String> getPublicPostEndpoints() {
+	// USER(회원) 권한
+	private List<String> getPubliCUserEndpoints() {
 		return List.of(
-
+			// 댓글 권한
+			"/api/v1/posts/*/comments",
+			"/api/v1/comments/*",
+			"/api/v1/comments/*/like"
 		);
 	}
 
-	private List<String> getPublicGetEndpoints() {
+	// ADMIN(관리자) 권한
+	private List<String> getPublicAdminEndpoints() {
 		return List.of(
-
+			// 댓글 권한
+			"/api/v1/posts/*/comments",
+			"/api/v1/comments/*",
+			"/api/v1/comments/*/like"
 		);
 	}
 

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -1,9 +1,14 @@
 package site.kkokkio.global.config;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -16,10 +21,16 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.global.security.CustomUserDetailsService;
+
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 @EnableMethodSecurity(prePostEnabled = true)
 public class SecurityConfig {
+
+	private final CustomUserDetailsService customUserDetailsService;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -41,21 +52,29 @@ public class SecurityConfig {
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
+			.authenticationProvider(authenticationProvider())
 
 			// 엔드포인트별 권한 설정
-			.authorizeHttpRequests(authorize -> authorize
-				// 인증 없이 접근 허용할 엔드포인트
-				// .requestMatchers(
-				// 	"/api/auth/**",        // 로그인·회원가입 등
-				// 	"/swagger-ui/**",      // Swagger UI
-				// 	"/v3/api-docs/**"      // OpenAPI 스펙
-				// ).permitAll()
+			.authorizeHttpRequests(authorize ->
+				authorize
+					// POST 요청에 대해 인증 없이 접근 허용
+					.requestMatchers(
+						HttpMethod.POST,
+						getPublicPostEndpoints().toArray(String[]::new)
+					).permitAll()
 
-				// 그 외 모든 요청은 인증 필요
-				// .anyRequest().authenticated()
+					// GET 요청에 대해 인증 없이 접근 허용
+					.requestMatchers(
+						HttpMethod.GET,
+						getPublicGetEndpoints().toArray(String[]::new)
+					).permitAll()
 
-				// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
-				.anyRequest().permitAll()
+					// 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
+					.requestMatchers(getPublicEndpoints().toArray(String[]::new)
+					).permitAll()
+
+					// 그 외 모든 요청은 인증 된 사용자 필요
+					.anyRequest().hasAnyRole("USER", "ADMIN")
 			);
 
 		return http.build();
@@ -66,11 +85,23 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 모든 출처 허용 (운영 환경 배포 시 수정 필요)
-		configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000")); // 프론트 운영 주소로 변경 필요
+		configuration.setAllowedOriginPatterns(Arrays.asList(
+			"https://login.aleph.kr",// Todo: 임시 프론트 배포 URL1
+			"https://www.app4.qwas.shop", // Todo: 임시 프론트 배포 URL2
+			"http://localhost:3000", // 로컬용
+			"https://api.deploy.kkokkio.site" // 백엔드 API URL
+		)); // 프론트 사이트 추가
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용 HTTP 메소드
 		configuration.setAllowedHeaders(Arrays.asList("*")); // HTTP 헤더(모두 허용)
 		configuration.setAllowCredentials(true); // 쿠키 등 자격 증명
-		configuration.addExposedHeader("Authorization"); // 클라이언트 노출 헤더
+		// 클라이언트 노출 헤더
+		configuration.setAllowedHeaders(List.of(
+			"Authorization",
+			"Content-Type",
+			"X-Requested-With",
+			"Accept",
+			"Origin"
+		));
 
 		// 모든 엔드포인트에 대해 CORS 설정 적용
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
@@ -78,9 +109,57 @@ public class SecurityConfig {
 		return source;
 	}
 
+	// DAO 기반 AuthenticationProvider 설정
+	@Bean
+	public DaoAuthenticationProvider authenticationProvider() {
+		DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+		provider.setUserDetailsService(customUserDetailsService);
+		provider.setPasswordEncoder(passwordEncoder());
+		return provider;
+	}
+
+	// AuthenticationManager를 AuthenticationConfiguration에서 가져오기
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+		return config.getAuthenticationManager();
+	}
+
 	// 패스워드 암호화를 위한 Bean
 	@Bean
 	public PasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
 	}
+
+	private List<String> getPublicEndpoints() {
+		return List.of(
+
+			// 로그인, 회원가입 등
+			"/api/v1/auth/**",
+
+			// Swagger UI 관련 경로 허용
+			"/swagger-ui/**",
+			"/swagger-ui.html",
+			"/swagger-resources/**",
+
+			// OpenAPI 스펙
+			"/v3/api-docs/**",
+			"/webjars/**",
+
+			// h2-console 확인
+			"/h2-console/**"
+		);
+	}
+
+	private List<String> getPublicPostEndpoints() {
+		return List.of(
+
+		);
+	}
+
+	private List<String> getPublicGetEndpoints() {
+		return List.of(
+
+		);
+	}
+
 }

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -57,24 +56,28 @@ public class SecurityConfig {
 			// 엔드포인트별 권한 설정
 			.authorizeHttpRequests(authorize ->
 				authorize
-					// POST 요청에 대해 인증 없이 접근 허용
-					.requestMatchers(
-						HttpMethod.POST,
-						getPublicPostEndpoints().toArray(String[]::new)
-					).permitAll()
+					// // POST 요청에 대해 인증 없이 접근 허용
+					// .requestMatchers(
+					// 	HttpMethod.POST,
+					// 	getPublicPostEndpoints().toArray(String[]::new)
+					// ).permitAll()
+					//
+					// // GET 요청에 대해 인증 없이 접근 허용
+					// .requestMatchers(
+					// 	HttpMethod.GET,
+					// 	getPublicGetEndpoints().toArray(String[]::new)
+					// ).permitAll()
+					//
+					// // 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
+					// .requestMatchers(getPublicEndpoints().toArray(String[]::new)
+					// ).permitAll()
+					//
+					// // 그 외 모든 요청은 인증 된 사용자 필요
+					// .anyRequest().hasAnyRole("USER", "ADMIN")
 
-					// GET 요청에 대해 인증 없이 접근 허용
-					.requestMatchers(
-						HttpMethod.GET,
-						getPublicGetEndpoints().toArray(String[]::new)
-					).permitAll()
+					// 개발을 위해 모두 오픈(운영 배포시 변경 예정)
+					.anyRequest().permitAll()
 
-					// 모든 HTTP 메소드에 대해 인증 없이 접근 가능한 경로
-					.requestMatchers(getPublicEndpoints().toArray(String[]::new)
-					).permitAll()
-
-					// 그 외 모든 요청은 인증 된 사용자 필요
-					.anyRequest().hasAnyRole("USER", "ADMIN")
 			);
 
 		return http.build();

--- a/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
+++ b/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
@@ -1,6 +1,9 @@
 package site.kkokkio.global.init;
 
+import java.time.LocalDate;
+
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +19,7 @@ import site.kkokkio.global.enums.MemberRole;
 public class BaseInitData implements CommandLineRunner {
 
 	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	@Override
 	public void run(String... args) throws Exception {
@@ -33,8 +37,9 @@ public class BaseInitData implements CommandLineRunner {
 		// 회원1 추가
 		Member member1 = Member.builder()
 			.email("user1@example.com")
-			.passwordHash("password123!")
+			.passwordHash(passwordEncoder.encode("password123!"))
 			.nickname("user1")
+			.birthDate(LocalDate.of(1990, 1, 1))
 			.role(MemberRole.USER)
 			.deletedAt(null)
 			.emailVerified(true)
@@ -44,8 +49,9 @@ public class BaseInitData implements CommandLineRunner {
 		// 회원2 추가
 		Member member2 = Member.builder()
 			.email("user2@example.com")
-			.passwordHash("password123!")
+			.passwordHash(passwordEncoder.encode("password123!"))
 			.nickname("user2")
+			.birthDate(LocalDate.of(1990, 1, 1))
 			.role(MemberRole.USER)
 			.deletedAt(null)
 			.emailVerified(true)
@@ -55,8 +61,9 @@ public class BaseInitData implements CommandLineRunner {
 		// 회원3 추가
 		Member member3 = Member.builder()
 			.email("test3@example.com")
-			.passwordHash("password123!")
+			.passwordHash(passwordEncoder.encode("password123!"))
 			.nickname("test3")
+			.birthDate(LocalDate.of(2000, 4, 10))
 			.role(MemberRole.USER)
 			.deletedAt(null)
 			.emailVerified(true)
@@ -66,8 +73,9 @@ public class BaseInitData implements CommandLineRunner {
 		// 관리자 추가
 		Member admin1 = Member.builder()
 			.email("admin1@example.com")
-			.passwordHash("password123!")
+			.passwordHash(passwordEncoder.encode("password123!"))
 			.nickname("admin1")
+			.birthDate(LocalDate.of(2025, 5, 1))
 			.role(MemberRole.ADMIN)
 			.deletedAt(null)
 			.emailVerified(true)

--- a/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
+++ b/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
@@ -1,0 +1,78 @@
+package site.kkokkio.global.init;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import site.kkokkio.domain.member.entity.Member;
+import site.kkokkio.domain.member.repository.MemberRepository;
+import site.kkokkio.global.enums.MemberRole;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BaseInitData implements CommandLineRunner {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public void run(String... args) throws Exception {
+		initMember();
+	}
+
+	// 회원 등록
+	@Transactional
+	public void initMember() {
+		if (memberRepository.count() > 0) {
+			log.info("이미 회원 데이터가 존재합니다.");
+			return;
+		}
+
+		// 회원1 추가
+		Member member1 = Member.builder()
+			.email("user1@example.com")
+			.passwordHash("password123!")
+			.nickname("user1")
+			.role(MemberRole.USER)
+			.deletedAt(null)
+			.emailVerified(true)
+			.build();
+		memberRepository.save(member1);
+
+		// 회원2 추가
+		Member member2 = Member.builder()
+			.email("user2@example.com")
+			.passwordHash("password123!")
+			.nickname("user2")
+			.role(MemberRole.USER)
+			.deletedAt(null)
+			.emailVerified(true)
+			.build();
+		memberRepository.save(member2);
+
+		// 회원3 추가
+		Member member3 = Member.builder()
+			.email("test3@example.com")
+			.passwordHash("password123!")
+			.nickname("test3")
+			.role(MemberRole.USER)
+			.deletedAt(null)
+			.emailVerified(true)
+			.build();
+		memberRepository.save(member3);
+
+		// 관리자 추가
+		Member admin1 = Member.builder()
+			.email("admin1@example.com")
+			.passwordHash("password123!")
+			.nickname("admin1")
+			.role(MemberRole.ADMIN)
+			.deletedAt(null)
+			.emailVerified(true)
+			.build();
+		memberRepository.save(admin1);
+		log.info("회원 데이터가 등록되었습니다.");
+	}
+}

--- a/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
+++ b/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
@@ -3,6 +3,7 @@ package site.kkokkio.global.init;
 import java.time.LocalDate;
 
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,7 @@ import site.kkokkio.global.enums.MemberRole;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@Profile({"local", "dev"})
 public class BaseInitData implements CommandLineRunner {
 
 	private final MemberRepository memberRepository;

--- a/backend/src/main/java/site/kkokkio/global/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/site/kkokkio/global/security/CustomUserDetailsService.java
@@ -1,0 +1,49 @@
+package site.kkokkio.global.security;
+
+import java.util.List;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import site.kkokkio.domain.member.entity.Member;
+import site.kkokkio.domain.member.repository.MemberRepository;
+import site.kkokkio.global.enums.MemberRole;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final MemberRepository memberRepository;
+
+	public CustomUserDetailsService(MemberRepository memberRepository) {
+		this.memberRepository = memberRepository;
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		Member member = memberRepository.findByEmail(email)
+			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+		// MemberRole -> GrantedAuthority 매핑
+		List<SimpleGrantedAuthority> authorities = List.of(
+			new SimpleGrantedAuthority("ROLE_" + member.getRole().name())
+		);
+
+		// 계정 활성화 및 잠금 상태 설정
+		boolean enabled = member.isEmailVerified() && !member.isDeleted();
+		boolean accountNonLocked = member.getRole() != MemberRole.BLACK;
+
+		return new User(
+			member.getEmail(),
+			member.getPasswordHash(),
+			enabled,
+			true,
+			true,
+			accountNonLocked,
+			authorities
+		);
+	}
+}

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -126,6 +126,8 @@ public class JwtUtils {
 		ResponseCookie cookie = ResponseCookie.from("access-token", token)
 			.httpOnly(true) // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/") // 전체 사이트에서 접근 가능
+
+			// Todo: 프론트, 백엔드 도메인 일치 후(Strict)적용
 			.sameSite("None") // 외부 사이트 요청 차단 (CSRF 방지)
 			.maxAge(Duration.ofMillis(expiration)) // Access Token 만료 시간 : 10분
 			.secure(true) // HTTPS 통신 시에만 전송
@@ -140,6 +142,8 @@ public class JwtUtils {
 		ResponseCookie cookie = ResponseCookie.from("refresh_token", token)
 			.httpOnly(true)     // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/auth")      // 인증 경로에서만 접근 가능
+
+			// Todo: 프론트, 백엔드 도메인 일치 후(Strict)적용
 			.sameSite("None")   // 외부 사이트 요청 허용 (CORS 환경 대응)
 			.maxAge(Duration.ofMillis(refreshTokenExpiration)) // Refresh Token 만료 시간 : 7일
 			.secure(true)       // HTTPS 통신 시에만 전송

--- a/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
@@ -22,6 +22,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -33,9 +35,11 @@ import site.kkokkio.domain.comment.dto.CommentDto;
 import site.kkokkio.domain.comment.service.CommentService;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.config.SecurityConfig;
+import site.kkokkio.global.security.CustomUserDetailsService;
 
 @WebMvcTest(CommentControllerV1.class)
 @Import(SecurityConfig.class)
+@WithMockUser(roles = {"USER"})
 class CommentControllerV1Test {
 
 	@Autowired
@@ -46,6 +50,9 @@ class CommentControllerV1Test {
 
 	@Autowired
 	private ObjectMapper objectMapper;
+
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
 
 	@Test
 	@DisplayName("댓글 목록 조회 성공")
@@ -74,7 +81,13 @@ class CommentControllerV1Test {
 			.thenReturn(commentDto);
 
 		mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts/1/comments")
-				.with(authentication(new UsernamePasswordAuthenticationToken(mock(Member.class), null, List.of())))
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(
+						mock(Member.class),
+						null,
+						List.of(new SimpleGrantedAuthority("ROLE_USER"))
+					)
+				))
 				.with(csrf())
 				.contentType(APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
@@ -89,7 +102,13 @@ class CommentControllerV1Test {
 		CommentCreateRequest request = new CommentCreateRequest(""); // 비어있는 body
 
 		mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/posts/1/comments")
-				.with(authentication(new UsernamePasswordAuthenticationToken(mock(Member.class), null, List.of())))
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(
+						mock(Member.class),
+						null,
+						List.of(new SimpleGrantedAuthority("ROLE_USER"))
+					)
+				))
 				.with(csrf())
 				.contentType(APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
@@ -106,7 +125,13 @@ class CommentControllerV1Test {
 			.thenReturn(commentDto);
 
 		mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/comments/1")
-				.with(authentication(new UsernamePasswordAuthenticationToken(mock(Member.class), null, List.of())))
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(
+						mock(Member.class),
+						null,
+						List.of(new SimpleGrantedAuthority("ROLE_USER"))
+					)
+				))
 				.with(csrf())
 				.contentType(APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
@@ -121,7 +146,13 @@ class CommentControllerV1Test {
 		CommentCreateRequest request = new CommentCreateRequest(""); // 비어있는 body
 
 		mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/comments/1")
-				.with(authentication(new UsernamePasswordAuthenticationToken(mock(Member.class), null, List.of())))
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(
+						mock(Member.class),
+						null,
+						List.of(new SimpleGrantedAuthority("ROLE_USER"))
+					)
+				))
 				.with(csrf())
 				.contentType(APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
@@ -132,7 +163,13 @@ class CommentControllerV1Test {
 	@DisplayName("댓글 삭제 성공")
 	void test4() throws Exception {
 		mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/comments/1")
-				.with(authentication(new UsernamePasswordAuthenticationToken(mock(Member.class), null, List.of())))
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(
+						mock(Member.class),
+						null,
+						List.of(new SimpleGrantedAuthority("ROLE_USER"))
+					)
+				))
 				.with(csrf())
 				.accept(APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -149,7 +186,13 @@ class CommentControllerV1Test {
 			.thenReturn(commentDto);
 
 		mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/comments/1/like")
-				.with(authentication(new UsernamePasswordAuthenticationToken(mock(Member.class), null, List.of())))
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(
+						mock(Member.class),
+						null,
+						List.of(new SimpleGrantedAuthority("ROLE_USER"))
+					)
+				))
 				.with(csrf()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))


### PR DESCRIPTION
## 연관된 이슈

> ex)#69 #70 #72   
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 테스트를 위한 baseInitData로 회원과 관리자 등록
- SecurityConfig 권한 설정
   - Comment(댓글) - 로그인한 유저만 사용할 수 있도록 권한 부여
- 프론트 엔드(임시) 도메인 반영

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #72