### PR TITLE
Feat/34 get hot sources from keyword api

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordControllerV1.java
@@ -1,5 +1,6 @@
 package site.kkokkio.domain.keyword.controller;
 
+import java.util.List;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -14,9 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.controller.dto.KeywordSearchSourceListResponse;
 import site.kkokkio.domain.keyword.service.KeywordService;
 import site.kkokkio.domain.post.dto.PostDto;
 import site.kkokkio.domain.post.dto.PostListResponse;
+import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.dto.RsData;
 import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
 import site.kkokkio.global.exception.doc.ErrorCode;
@@ -28,6 +32,7 @@ import site.kkokkio.global.exception.doc.ErrorCode;
 public class KeywordControllerV1 {
 
 	private final KeywordService keywordService;
+	private final SourceService sourceService;
 
 	@GetMapping("/search")
 	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_3})
@@ -44,4 +49,24 @@ public class KeywordControllerV1 {
 			response
 		);
 	}
+
+    @Operation(
+        summary = "키워드 검색 출처 5개 최신순 조회 (페이지네이션)",
+        description = "키워드 검색 결과인 포스트 목록 기준으로 최신순 출처 목록을 조회힙니다. (없을 경우 빈 배열 반환)"
+    )
+    @ApiErrorCodeExamples({})
+    @GetMapping("/search/sources/top")
+    public RsData<KeywordSearchSourceListResponse> getKeywordSearchSources(
+		@RequestParam String keyword,
+        @ParameterObject @PageableDefault() Pageable pageable
+    ) {
+		Page<PostDto> postDtoList = keywordService.getPostListByKeyword(keyword, pageable);
+        List<SourceDto> searchSourceList = sourceService.getTop5SourcesByPosts(postDtoList.toList());
+		KeywordSearchSourceListResponse response = KeywordSearchSourceListResponse.from(searchSourceList);
+		return new RsData<>(
+			"200",
+			"성공적으로 조회되었습니다.",
+			response
+		);
+    }
 }

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/dto/KeywordSearchSourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/dto/KeywordSearchSourceListResponse.java
@@ -1,0 +1,40 @@
+package site.kkokkio.domain.keyword.controller.dto;
+
+import java.util.List;
+
+import org.springframework.lang.NonNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.global.enums.Platform;
+
+@Builder
+@Schema(description = "키워드 검색 출처 5개 최신순 조회 DTO (페이지네이션 포함)")
+public record KeywordSearchSourceListResponse(
+	List<SearchSourceList> list
+) {
+
+	public static KeywordSearchSourceListResponse from(List<SourceDto> searchSourceList) {
+        return KeywordSearchSourceListResponse.builder()
+                .list(searchSourceList.stream().map(SearchSourceList::from).toList())
+                .build();
+    }
+
+	@Builder
+	private record SearchSourceList(
+		@NonNull String url,
+		String thumbnailUrl,
+		@NonNull String title,
+		@NonNull Platform platform
+		) {
+		public static SearchSourceList from(SourceDto sourceDto) {
+			return SearchSourceList.builder()
+				.url(sourceDto.url())
+				.thumbnailUrl(sourceDto.thumbnailUrl())
+				.title(sourceDto.title())
+				.platform(sourceDto.platform())
+				.build();
+		}
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.post.service.PostService;
 import site.kkokkio.domain.source.controller.dto.SourceListResponse;
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/SourceDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/SourceDto.java
@@ -6,20 +6,23 @@ import org.springframework.lang.NonNull;
 
 import lombok.Builder;
 import site.kkokkio.domain.source.entity.Source;
+import site.kkokkio.global.enums.Platform;
 
 @Builder
 public record SourceDto(
 	@NonNull String url,
-	@NonNull String thumbnailUrl,
+	String thumbnailUrl,
 	@NonNull String title,
-	@NonNull LocalDateTime publishedAt
-) {
+	@NonNull LocalDateTime publishedAt,
+	@NonNull Platform platform
+	) {
 	public static SourceDto from(Source source) {
 		return SourceDto.builder()
 			.url(source.getNormalizedUrl())
 			.thumbnailUrl(source.getThumbnailUrl())
 			.title(source.getTitle())
 			.publishedAt(source.getPublishedAt())
+			.platform(source.getPlatform())
 			.build();
 	}
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/SourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/SourceRepository.java
@@ -1,10 +1,23 @@
 package site.kkokkio.domain.source.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import site.kkokkio.domain.source.entity.Source;
 
 @Repository
 public interface SourceRepository extends JpaRepository<Source, String> {
+
+	@Query("""
+		SELECT ps.source
+		FROM PostSource ps
+		WHERE ps.post.id IN :postIds
+		ORDER BY ps.source.publishedAt DESC
+		""")
+	List<Source> findByPostIdsOrderByPublishedAtDesc(@Param("postIds") List<Long> postIds, Pageable pageable);
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
@@ -18,6 +18,7 @@ import reactor.core.publisher.Mono;
 import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyDto;
 import site.kkokkio.domain.keyword.entity.Keyword;
 import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
+import site.kkokkio.domain.post.dto.PostDto;
 import site.kkokkio.domain.post.service.PostService;
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.NewsDto;
@@ -73,6 +74,19 @@ public class SourceService {
 		return postSources.stream()
 			.map(ps -> SourceDto.from(ps.getSource()))
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public List<SourceDto> getTop5SourcesByPosts(List<PostDto> postDtoList) {
+		if (postDtoList == null || postDtoList.isEmpty()) {
+			return Collections.emptyList();
+		}
+		List<Long> postIds = postDtoList.stream().map(PostDto::postId).toList();
+
+		PageRequest pageRequest = PageRequest.of(0, 5); // 5개 고정
+		List<Source> top5SourcesByPostIds = sourceRepository.findByPostIdsOrderByPublishedAtDesc(postIds, pageRequest);
+
+		return top5SourcesByPostIds.stream().map(SourceDto::from).toList();
 	}
 
 	/**

--- a/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
@@ -1,28 +1,32 @@
 package site.kkokkio.domain.source.controller;
 
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
 import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = SourceControllerV1.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -39,11 +43,11 @@ class SourceControllerV1Test {
     void getNewsSources_Success() throws Exception {
         // given
         List<SourceDto> mockNewsList = List.of(
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"))
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
+                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS)
         );
         given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(mockNewsList);
 
@@ -101,11 +105,11 @@ class SourceControllerV1Test {
     void getVideoSources_Success() throws Exception {
         // given
         List<SourceDto> mockVideoList = List.of(
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목1", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목2", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목3", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목4", LocalDateTime.parse("2024-04-29T15:30:00")),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목5", LocalDateTime.parse("2024-04-29T15:30:00"))
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목1", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목2", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목3", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목4", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목5", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE)
         );
         given(sourceService.getTop10VideoSourcesByPostId(anyLong())).willReturn(mockVideoList);
 

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,6 +1,6 @@
 setup:
   - project: kkokkio-backend
-    config: dev
+    config: local
     path: backend
   - project: kkokkio-infra
     config: dev


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #34 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
키워드 화면에 노출될 포스트 기반 출처 최신순 리스트 조회 API를 구현했습니다.
- 최대 5개로 고정되어 출력되며, 포스트가 없거나 출처가 없을 시 에러 대신 빈 배열이 반환됩니다.

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #34