### PR TITLE
Feat/97 token exception

### DIFF
--- a/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package site.kkokkio.global.exception;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.http.HttpStatus;
@@ -82,16 +83,16 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(CustomAuthException.class)
-	public ResponseEntity<RsData<Void>> handleCustomAuthException(CustomAuthException e) {
+	public ResponseEntity<Map<String, Object>> handleCustomAuthException(CustomAuthException e) {
 
+		Map<String, Object> body = Map.of(
+			"status_code", HttpStatus.UNAUTHORIZED.value(),   // 401
+			"err_code", e.getAuthErrorType().name(),      // ex) "TOKEN_EXPIRED"
+			"message", e.getMessage()                    // ex) "만료된 토큰: 2025-05-04T09:56:00"
+		);
 		return ResponseEntity
 			.status(HttpStatus.UNAUTHORIZED)
-			.body(
-				new RsData<>(
-					"401",
-					"%s에 대한 에러 발생".formatted(e.getAuthErrorType().name())
-				)
-			);
+			.body(body);
 	}
 
 }

--- a/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/GlobalExceptionHandler.java
@@ -80,4 +80,18 @@ public class GlobalExceptionHandler {
 				)
 			);
 	}
+
+	@ExceptionHandler(CustomAuthException.class)
+	public ResponseEntity<RsData<Void>> handleCustomAuthException(CustomAuthException e) {
+
+		return ResponseEntity
+			.status(HttpStatus.UNAUTHORIZED)
+			.body(
+				new RsData<>(
+					"401",
+					"%s에 대한 에러 발생".formatted(e.getAuthErrorType().name())
+				)
+			);
+	}
+
 }

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -55,8 +55,8 @@ public class JwtUtils {
 				.getExpiration();
 		} catch (JwtException | IllegalArgumentException e) {
 			handleAuthException(e);
-			throw e; // 위에서 예외 처리하므로 실질적으로 실행되지 않음 (명시용)
 		}
+		return null;
 	}
 
 	// Refresh Token 만료 시간 반환
@@ -90,10 +90,10 @@ public class JwtUtils {
 			.compact();
 	}
 
-	// JWT 유효성 검사
-	private boolean isValidToken(String token) {
+	// JWT 유효성 검사 <- 토큰이 유효하지 않으면 CustomAuthException을 던진다.
+	public boolean isValidToken(String token) {
+		SecretKey key = getSecretKey();
 		try {
-			SecretKey key = getSecretKey();
 			Jwts.parser()
 				.verifyWith(key)
 				.build()


### PR DESCRIPTION
## 연관된 이슈

> ex) #97 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 토큰 관련 응답 형식 정의


## 스크린샷 (선택)

- 에러 타입 정의(Json)
```
@RequiredArgsConstructor
	public enum AuthErrorType {
		TOKEN_EXPIRED, // 토큰 만료
		UNSUPPORTED_TOKEN, // 지원되지 않는 토큰 형식
		MALFORMED_TOKEN, // 토큰 구조 오류
		CREDENTIALS_MISMATCH; // 인증 정보 불일치
	}
```
- 예상 HTTP 응답
```
HTTP/1.1 401 Unauthorized
Content-Type: application/json
```
- 응답 형태 및 예시(json)
```
"status_code", HttpStatus.UNAUTHORIZED.value(), // 401
"err_code", e.getAuthErrorType().name(), // ex) "TOKEN_EXPIRED"
"message", e.getMessage() // ex) "만료된 토큰: 2025-05-04T09:56:00"
```

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- 기존 RsData 형식으로 응답 제공하려다, 프론트 개발자님이 정리해준 응답 형태에 message만 추가한 형태로 변경했습니다.
closes #97