### PR TITLE
Feat/99 GET /member/me 구현(회원정보조회)

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
@@ -1,0 +1,96 @@
+package site.kkokkio.domain.member.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.mail.MessagingException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
+import site.kkokkio.domain.member.controller.dto.MemberLoginRequest;
+import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
+import site.kkokkio.domain.member.dto.TokenDto;
+import site.kkokkio.domain.member.service.AuthService;
+import site.kkokkio.domain.member.service.MailService;
+import site.kkokkio.domain.member.service.MemberService;
+import site.kkokkio.global.dto.RsData;
+import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
+import site.kkokkio.global.exception.doc.ErrorCode;
+import site.kkokkio.global.util.JwtUtils;
+
+@Tag(name = "Auth API", description = "인증 관련 기능을 제공")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthControllerV1 {
+
+	private final MemberService memberService;
+	private final AuthService authService;
+	private final JwtUtils jwtUtils;
+	private final MailService mailService;
+
+	// 로그인
+	@Operation(summary = "로그인")
+	@ApiErrorCodeExamples({ErrorCode.EMAIL_NOT_FOUND, ErrorCode.PASSWORD_UNAUTHORIZED})
+	@PostMapping("/login")
+	public RsData<MemberLoginResponse> login(
+		@RequestBody @Validated MemberLoginRequest request,
+		HttpServletResponse response
+	) {
+
+		// 로그인 서비스 호출
+		MemberLoginResponse loginResponse = authService.login(request.email(), request.passwordHash(), response);
+
+		// JWT 토큰 쿠키에 설정
+		jwtUtils.setJwtInCookie(loginResponse.token(), response);
+		//
+		jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
+
+		return new RsData<>("200", "로그인 성공", loginResponse);
+	}
+
+	@Operation(summary = "토큰 재발급")
+	@PostMapping("/refresh")
+	@ApiErrorCodeExamples({ErrorCode.REFRESH_TOKEN_NOT_FOUND,
+		ErrorCode.REFRESH_TOKEN_MISMATCH, ErrorCode.REFRESH_TOKEN_INTERNAL_ERROR})
+	public RsData<TokenDto> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+		TokenDto tokenDto = authService.refreshToken(request, response);
+		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenDto);
+	}
+
+	@Operation(summary = "로그아웃")
+	@PostMapping("/logout")
+	@ApiErrorCodeExamples({ErrorCode.LOGOUT_BAD_REQUEST, ErrorCode.LOGOUT_INTERNAL_SERVER_ERROR})
+	public RsData<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		authService.logout(request, response);
+		return new RsData<>("200", "로그아웃 되었습니다.");
+	}
+
+	@Operation(summary = "이메일 인증 코드 전송")
+	@PostMapping("/verify-email")
+	public RsData<Void> requestAuthCode(@RequestParam String email) throws MessagingException {
+
+		boolean isSend = mailService.sendAuthCode(email);
+		return isSend
+			? new RsData<>("200", "인증 코드가 전송되었습니다.")
+			: new RsData<>("500", "인증 코드 전송이 실패하였습니다.");
+	}
+
+	@Operation(summary = "이메일 인증")
+	@PostMapping("/check-email")
+	public RsData<Void> validateAuthCode(@RequestBody @Valid EmailVerificationRequest emailVerificationRequestDto) {
+
+		boolean isSuccess = mailService.validationAuthCode(emailVerificationRequestDto);
+		return isSuccess
+			? new RsData<>("200", "이메일 인증에 성공하였습니다.")
+			: new RsData<>("400", "이메일 인증에 실패하였습니다.");
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -4,22 +4,13 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.mail.MessagingException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
-import site.kkokkio.domain.member.controller.dto.MemberLoginRequest;
-import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
-import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -31,7 +22,7 @@ import site.kkokkio.global.util.JwtUtils;
 @Tag(name = "Member API", description = "회원 관련 기능을 제공")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1/member")
 public class MemberControllerV1 {
 
 	private final MemberService memberService;
@@ -46,63 +37,6 @@ public class MemberControllerV1 {
 	public RsData<MemberResponse> createMember(@RequestBody @Validated MemberSignUpRequest request) {
 		MemberResponse memberResponse = memberService.createMember(request);
 		return new RsData<>("200", "회원가입이 완료되었습니다.", memberResponse);
-	}
-
-	// 로그인
-	@Operation(summary = "로그인")
-	@ApiErrorCodeExamples({ErrorCode.EMAIL_NOT_FOUND, ErrorCode.PASSWORD_UNAUTHORIZED})
-	@PostMapping("/login")
-	public RsData<MemberLoginResponse> login(
-		@RequestBody @Validated MemberLoginRequest request,
-		HttpServletResponse response
-	) {
-
-		// 로그인 서비스 호출
-		MemberLoginResponse loginResponse = authService.login(request.email(), request.passwordHash(), response);
-
-		// JWT 토큰 쿠키에 설정
-		jwtUtils.setJwtInCookie(loginResponse.token(), response);
-		//
-		jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
-
-		return new RsData<>("200", "로그인 성공", loginResponse);
-	}
-
-	@Operation(summary = "토큰 재발급")
-	@PostMapping("/refresh")
-	@ApiErrorCodeExamples({ErrorCode.REFRESH_TOKEN_NOT_FOUND,
-		ErrorCode.REFRESH_TOKEN_MISMATCH, ErrorCode.REFRESH_TOKEN_INTERNAL_ERROR})
-	public RsData<TokenDto> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-		TokenDto tokenDto = authService.refreshToken(request, response);
-		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenDto);
-	}
-
-	@Operation(summary = "로그아웃")
-	@PostMapping("/logout")
-	@ApiErrorCodeExamples({ErrorCode.LOGOUT_BAD_REQUEST, ErrorCode.LOGOUT_INTERNAL_SERVER_ERROR})
-	public RsData<Void> logout(HttpServletRequest request, HttpServletResponse response) {
-		authService.logout(request, response);
-		return new RsData<>("200", "로그아웃 되었습니다.");
-	}
-
-	@Operation(summary = "이메일 인증 코드 전송")
-	@PostMapping("/verify-email")
-	public RsData<Void> requestAuthCode(@RequestParam String email) throws MessagingException {
-
-		boolean isSend = mailService.sendAuthCode(email);
-		return isSend
-			? new RsData<>("200", "인증 코드가 전송되었습니다.")
-			: new RsData<>("500", "인증 코드 전송이 실패하였습니다.");
-	}
-
-	@Operation(summary = "이메일 인증")
-	@PostMapping("/check-email")
-	public RsData<Void> validateAuthCode(@RequestBody @Valid EmailVerificationRequest emailVerificationRequestDto) {
-
-		boolean isSuccess = mailService.validationAuthCode(emailVerificationRequestDto);
-		return isSuccess
-			? new RsData<>("200", "이메일 인증에 성공하였습니다.")
-			: new RsData<>("400", "이메일 인증에 실패하였습니다.");
 	}
 
 }

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -1,6 +1,7 @@
 package site.kkokkio.domain.member.controller;
 
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
@@ -39,4 +41,16 @@ public class MemberControllerV1 {
 		return new RsData<>("200", "회원가입이 완료되었습니다.", memberResponse);
 	}
 
+	// 회원 정보 조회
+	@Operation(summary = "회원조회")
+	@ApiErrorCodeExamples({ErrorCode.MEMBER_ME_BAD_REQUEST})
+	@GetMapping("/me")
+	public RsData<MemberResponse> getMember(HttpServletRequest request) {
+		MemberResponse memberInfo = memberService.getMemberInfo(request);
+		return new RsData<>(
+			"200",
+			"마이페이지 조회 성공",
+			memberInfo
+		);
+	}
 }

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 	REFRESH_TOKEN_NOT_FOUND("401-1", "리프레시 토큰이 없습니다."),
 	REFRESH_TOKEN_MISMATCH("401-2", "유효하지 않은 리프레시 토큰입니다."),
 	REFRESH_TOKEN_INTERNAL_ERROR("500", "리프레시 토큰 처리 중 서버 오류가 발생했습니다."),
+	MEMBER_ME_BAD_REQUEST("400", "마이페이지 조회 실패"),
 	COMMENT_NOT_FOUND("404", "존재하지 않는 댓글입니다."),
 	COMMENT_UPDATE_FORBIDDEN("403", "본인 댓글만 수정할 수 있습니다."),
 	COMMENT_DELETE_FORBIDDEN("403", "본인 댓글만 삭제할 수 있습니다."),

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/AuthControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/AuthControllerV1Test.java
@@ -1,0 +1,219 @@
+package site.kkokkio.domain.member.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
+import site.kkokkio.domain.member.dto.TokenDto;
+import site.kkokkio.domain.member.service.AuthService;
+import site.kkokkio.domain.member.service.MailService;
+import site.kkokkio.domain.member.service.MemberService;
+import site.kkokkio.global.aspect.ResponseAspect;
+import site.kkokkio.global.enums.MemberRole;
+import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.util.JwtUtils;
+
+@WebMvcTest(AuthControllerV1.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ResponseAspect.class)               // ① AOP 빈 등록
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+public class AuthControllerV1Test {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private MemberService memberService;
+
+	@MockitoBean
+	private JwtUtils jwtUtils;
+
+	@MockitoBean
+	private MailService mailService;
+
+	@MockitoBean
+	private AuthService authService;
+
+	@Test
+	@DisplayName("로그인 - 성공")
+	void loginSuccess() throws Exception {
+		// given
+		MemberLoginResponse loginResponse = MemberLoginResponse.builder()
+			.nickname("테스트쟁이")
+			.email("test@test.com")
+			.deleteAt(null)
+			.role(MemberRole.USER)
+			.token("tokenTest")
+			.build();
+		given(authService.login(eq("test@test.com"), eq("passHash"), any(HttpServletResponse.class)))
+			.willReturn(loginResponse);
+		willDoNothing().given(jwtUtils)
+			.setJwtInCookie(eq("tokenTest"), any(HttpServletResponse.class));
+
+		String loginJson = """
+			{
+			  "email":"test@test.com",
+			  "passwordHash":"passHash"
+			}
+			""";
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginJson))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("로그인 성공"))
+			.andExpect(jsonPath("$.data.nickname").value("테스트쟁이"))
+			.andExpect(jsonPath("$.data.email").value("test@test.com"))
+			.andExpect(jsonPath("$.data.role").value("USER"));
+	}
+
+	@Test
+	@DisplayName("로그인 - 실패 (인증 오류)")
+	void loginFailure() throws Exception {
+		// given
+		given(authService.login(anyString(), anyString(), any(HttpServletResponse.class)))
+			.willThrow(new ServiceException("401", "로그인에 실패했습니다."));
+
+		String loginJson = """
+			{
+			  "email":"bad@test.com",
+			  "passwordHash":"wrong"
+			}
+			""";
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginJson))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code").value("401"))
+			.andExpect(jsonPath("$.message").value("로그인에 실패했습니다."));
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 - 성공")
+	void refreshTokenSuccess() throws Exception {
+		// given
+		TokenDto tokenDto = new TokenDto("newAccessToken", "existingRefreshToken");
+
+		given(authService.refreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+			.willReturn(tokenDto);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/refresh"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
+			.andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
+			.andExpect(jsonPath("$.data.refreshToken").value("existingRefreshToken"));
+	}
+
+	@Test
+	@DisplayName("로그아웃 - 성공")
+	void logoutSuccess() throws Exception {
+		// given
+		willDoNothing().given(authService)
+			.logout(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/logout"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("로그아웃 되었습니다."));
+	}
+
+	@Test
+	@DisplayName("이메일 인증 코드 전송 - 성공")
+	void sendAuthCodeSuccess() throws Exception {
+		// given
+		given(mailService.sendAuthCode("test@example.com"))
+			.willReturn(true);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/verify-email")
+				.param("email", "test@example.com"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("인증 코드가 전송되었습니다."));
+	}
+
+	@Test
+	@DisplayName("이메일 인증 코드 전송 - 실패")
+	void sendAuthCodeFailure() throws Exception {
+		// given
+		given(mailService.sendAuthCode("test@example.com"))
+			.willReturn(false);
+
+		// when & then
+		mockMvc.perform(post("/api/v1/auth/verify-email")
+				.param("email", "test@example.com"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.code").value("500"))
+			.andExpect(jsonPath("$.message").value("인증 코드 전송이 실패하였습니다."));
+	}
+
+	// 이메일 인증 검사는 실제 메일로 검사 필요
+
+	// @Test
+	// @DisplayName("이메일 인증 검사 - 성공")
+	// void checkEmailSuccess() throws Exception {
+	// 	// given
+	// 	given(mailService.validationAuthCode(any(EmailVerificationRequest.class)))
+	// 		.willReturn(true);
+	//
+	// 	String checkJson = """
+	// 		{
+	// 		  "email":"test@example.com",
+	// 		  "code":"123456"
+	// 		}
+	// 		""";
+	//
+	// 	// when & then
+	// 	mockMvc.perform(post("/api/v1/auth/check-email")
+	// 			.contentType(MediaType.APPLICATION_JSON)
+	// 			.content(checkJson))
+	// 		.andExpect(status().isOk())
+	// 		.andExpect(jsonPath("$.code").value("200"))
+	// 		.andExpect(jsonPath("$.message").value("이메일 인증에 성공하였습니다."));
+	// }
+	//
+	// @Test
+	// @DisplayName("이메일 인증 검사 - 실패")
+	// void checkEmailFailure() throws Exception {
+	// 	// given
+	// 	given(mailService.validationAuthCode(any(EmailVerificationRequest.class)))
+	// 		.willReturn(false);
+	//
+	// 	String checkJson = """
+	// 		{
+	// 		  "email":"test@example.com",
+	// 		  "code":"000000"
+	// 		}
+	// 		""";
+	//
+	// 	// when & then
+	// 	mockMvc.perform(post("/api/v1/auth/check-email")
+	// 			.contentType(MediaType.APPLICATION_JSON)
+	// 			.content(checkJson))
+	// 		.andExpect(status().isBadRequest())
+	// 		.andExpect(jsonPath("$.code").value("400"))
+	// 		.andExpect(jsonPath("$.message").value("이메일 인증에 실패하였습니다."));
+	// }
+}


### PR DESCRIPTION
## 연관된 이슈

> ex) #99 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- Auth와 Member Controller 분리
- auth/signup -> member/signup으로 회원가입 API 엔드포인트 변경
- 회원정보조회구현(GET member/me)
- 회원정보(JWT토큰기준) 성공/실패 test 코드 작성 및 통과

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- 프론트 개발자분께서 토큰 확인을 위해 회원정보확인을 우선순위를 높여달라고 하셔서 먼저 개발했습니다.
- 인증과 회원 로직을 분리하면서 회원가입 API 엔드 포인트가 Member로 변경되었습니다.

closes #99