### PR TITLE
Feat/80 jwt filter

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,3 +38,6 @@ out/
 
 # Redis persistence file
 redis_data/
+
+# Local 환경의 BaseInit 데이터(GODAOS)
+src/main/java/site/kkokkio/global/init/BaseInitDataLocal.java

--- a/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
@@ -22,11 +22,11 @@ import site.kkokkio.domain.comment.controller.dto.CommentCreateRequest;
 import site.kkokkio.domain.comment.controller.dto.CommentListResponse;
 import site.kkokkio.domain.comment.dto.CommentDto;
 import site.kkokkio.domain.comment.service.CommentService;
-import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.dto.Empty;
 import site.kkokkio.global.dto.RsData;
 import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
 import site.kkokkio.global.exception.doc.ErrorCode;
+import site.kkokkio.global.security.CustomUserDetails;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -58,9 +58,9 @@ public class CommentControllerV1 {
 	@PostMapping("/posts/{postId}/comments")
 	public RsData<CommentDto> createComment(
 		@PathVariable("postId") Long postId,
-		@AuthenticationPrincipal Member member, /*TODO: 인증/인가 구현 후 UserDetails 구현체로 변경*/
+		@AuthenticationPrincipal CustomUserDetails userDetails, /* 인증/인가 구현 후 UserDetails 구현체로 변경 완료*/
 		@Valid @RequestBody CommentCreateRequest request) {
-		CommentDto comment = commentService.createComment(postId, member, request);
+		CommentDto comment = commentService.createComment(postId, userDetails.getMember(), request);
 		return new RsData<>(
 			"200",
 			"댓글이 등록되었습니다.",
@@ -73,10 +73,10 @@ public class CommentControllerV1 {
 	@PatchMapping("/comments/{commentId}")
 	public RsData<CommentDto> updateComment(
 		@PathVariable("commentId") Long commentId,
-		@AuthenticationPrincipal Member member, /*TODO: 인증/인가 구현 후 UserDetails 구현체로 변경*/
+		@AuthenticationPrincipal CustomUserDetails userDetails, /* 인증/인가 구현 후 UserDetails 구현체로 변경 완료*/
 		@Valid @RequestBody CommentCreateRequest request
 	) {
-		CommentDto comment = commentService.updateComment(commentId, member, request);
+		CommentDto comment = commentService.updateComment(commentId, userDetails.getMember(), request);
 		return new RsData<>(
 			"200",
 			"댓글이 수정되었습니다.",
@@ -89,9 +89,9 @@ public class CommentControllerV1 {
 	@DeleteMapping("/comments/{commentId}")
 	public RsData<Empty> deleteComment(
 		@PathVariable("commentId") Long commentId,
-		@AuthenticationPrincipal Member member /*TODO: 인증/인가 구현 후 UserDetails 구현체로 변경*/
+		@AuthenticationPrincipal CustomUserDetails userDetails /* 인증/인가 구현 후 UserDetails 구현체로 변경 완료*/
 	) {
-		commentService.deleteCommentById(commentId, member);
+		commentService.deleteCommentById(commentId, userDetails.getMember());
 		return new RsData<>(
 			"204",
 			"댓글이 삭제되었습니다."
@@ -104,9 +104,9 @@ public class CommentControllerV1 {
 	@PostMapping("/comments/{commentId}/like")
 	public RsData<CommentDto> likeComment(
 		@PathVariable("commentId") Long commentId,
-		@AuthenticationPrincipal Member member /*TODO: 인증/인가 구현 후 UserDetails 구현체로 변경*/
+		@AuthenticationPrincipal CustomUserDetails userDetails /* 인증/인가 구현 후 UserDetails 구현체로 변경 완료*/
 	) {
-		CommentDto comment = commentService.likeComment(commentId, member);
+		CommentDto comment = commentService.likeComment(commentId, userDetails.getMember());
 		return new RsData<>(
 			"200",
 			"좋아요가 정상 처리되었습니다.",

--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -38,14 +38,12 @@ public class AuthService {
 		}
 
 		Map<String, Object> claims = new HashMap<>();
-		claims.put("id", member.getId());
-		claims.put("email", member.getEmail());
-		claims.put("nickname", member.getNickname());
+		claims.put("isEmailVerified", member.isEmailVerified());
 		claims.put("role", member.getRole());
 
 		// token, refreshToken 생성
-		String accessToken = jwtUtils.createToken(claims);
-		String refreshToken = jwtUtils.createRefreshToken(claims);
+		String accessToken = jwtUtils.createToken(member.getEmail(), claims);
+		String refreshToken = jwtUtils.createRefreshToken(member.getEmail(), claims);
 
 		// Redis에 Refresh Token 저장 (키: "refreshToken:<email>")
 		Duration rtTtl = Duration.ofMillis(jwtUtils.getRefreshTokenExpiration());
@@ -76,7 +74,7 @@ public class AuthService {
 
 		// 새로운 토큰 발급
 		Map<String, Object> claims = jwtUtils.getPayload(rt);
-		String newAt = jwtUtils.createToken(claims);
+		String newAt = jwtUtils.createToken(email, claims);
 
 		// 쿠키에도 업데이트
 		jwtUtils.setJwtInCookie(newAt, response);

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -24,7 +24,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
-import site.kkokkio.global.filter.JWTAuthenticationFilter;
+import site.kkokkio.global.filter.JwtAuthenticationFilter;
 import site.kkokkio.global.security.CustomUserDetailsService;
 import site.kkokkio.global.util.JwtUtils;
 
@@ -36,6 +36,7 @@ public class SecurityConfig {
 
 	private final CustomUserDetailsService customUserDetailsService;
 	private final RedisTemplate<String, String> redisTemplate;
+	private final JwtUtils jwtUtils;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtUtils jwtUtils) throws Exception {
@@ -63,8 +64,7 @@ public class SecurityConfig {
 			.authenticationProvider(authenticationProvider())
 
 			// JWT 인증 필터 추가
-			.addFilterBefore(new JWTAuthenticationFilter(jwtUtils, customUserDetailsService, redisTemplate),
-				UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
 
 			// 엔드포인트별 권한 설정
 			.authorizeHttpRequests(authorize ->
@@ -132,6 +132,12 @@ public class SecurityConfig {
 	@Bean
 	public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
 		return config.getAuthenticationManager();
+	}
+
+	// JwtAuthenticationFilter Bean 등록
+	@Bean
+	public JwtAuthenticationFilter jwtAuthenticationFilter() {
+		return new JwtAuthenticationFilter(jwtUtils, customUserDetailsService, redisTemplate);
 	}
 
 	// 패스워드 암호화를 위한 Bean

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
 	private final ObjectMapper objectMapper;
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtUtils jwtUtils) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
 		http
 			// CORS 설정 추가
@@ -165,7 +165,7 @@ public class SecurityConfig {
 	public AccessDeniedHandler customAccessDeniedHandler() {
 		return (request, response, accessDeniedException) -> {
 			response.setCharacterEncoding("UTF-8");
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 			response.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
 
 			RsData<Void> body = new RsData<>("403", "권한이 없습니다.");

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -74,11 +74,11 @@ public class SecurityConfig {
 					).permitAll()
 
 					// 댓글 GET 요청 허용
-					.requestMatchers(HttpMethod.GET, "/api/v1/posts/*/comments")
+					.requestMatchers(HttpMethod.GET, "/api/*/posts/*/comments")
 					.permitAll()
 
 					// 회원 권한
-					.requestMatchers(getPubliCUserEndpoints().toArray(String[]::new)).hasRole("USER")
+					.requestMatchers(getPublicUserEndpoints().toArray(String[]::new)).hasRole("USER")
 					// 관리자 권한
 					.requestMatchers(getPublicAdminEndpoints().toArray(String[]::new)).hasRole("ADMIN")
 
@@ -148,7 +148,7 @@ public class SecurityConfig {
 			"/",
 
 			// 로그인, 회원가입 등
-			"/api/v1/auth/**",
+			"/api/*/auth/**",
 
 			// Todo: 아래 엔드포인트는 개발 환경에서만, 운영 서버 반영 전 제거 필요
 
@@ -167,12 +167,12 @@ public class SecurityConfig {
 	}
 
 	// USER(회원) 권한
-	private List<String> getPubliCUserEndpoints() {
+	private List<String> getPublicUserEndpoints() {
 		return List.of(
 			// 댓글 권한
-			"/api/v1/posts/*/comments",
-			"/api/v1/comments/*",
-			"/api/v1/comments/*/like"
+			"/api/*/posts/*/comments",
+			"/api/*/comments/*",
+			"/api/*/comments/*/like"
 		);
 	}
 
@@ -180,9 +180,9 @@ public class SecurityConfig {
 	private List<String> getPublicAdminEndpoints() {
 		return List.of(
 			// 댓글 권한
-			"/api/v1/posts/*/comments",
-			"/api/v1/comments/*",
-			"/api/v1/comments/*/like"
+			"/api/*/posts/*/comments",
+			"/api/*/comments/*",
+			"/api/*/comments/*/like"
 		);
 	}
 

--- a/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
@@ -1,0 +1,125 @@
+package site.kkokkio.global.filter;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.global.security.CustomUserDetailsService;
+import site.kkokkio.global.util.JwtUtils;
+
+@RequiredArgsConstructor
+public class JWTAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtils jwtUtils;
+	private final CustomUserDetailsService userDetailsService;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		// 헤더에서 토큰 추출
+		String headerToken = extractTokenFromHeader(request);
+
+		// 쿠키에서 토큰 추출
+		String cookieToken = extractTokenFromCookie(request);
+
+		// 둘 중 하나라도 있으면 있증 처리
+		String token = headerToken != null ? headerToken : cookieToken;
+
+		if (token != null) {
+			try {
+				// 블랙리스트 확인
+				if (isTokenBlacklisted(token)) {
+					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "로그아웃된 토큰입니다.");
+					return;
+				}
+
+				Claims claims = jwtUtils.getClaims(token);
+				String email = claims.getSubject();
+				String role = claims.get("role", String.class);
+				Boolean isVerified = claims.get("isEmailVerified", Boolean.class);
+
+				// Redis에 저장된 액세스 토큰과 일치하는지 확인
+				if (!isTokenInRedis(email, token)) {
+					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+					return;
+				}
+
+				if (email != null && Boolean.TRUE.equals(isVerified)) {
+					// UserDetails 객체 생성 (DB에서 사용자 정보 조회)
+					UserDetails userDetails = userDetailsService.loadUserByUsername(email);
+					List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
+
+					// UserDetails 기반으로 Authentication 객체 생성
+					UsernamePasswordAuthenticationToken authentication =
+						new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+
+					// SecurityContextHolder에 인증 정보 설정
+					SecurityContextHolder.getContext().setAuthentication(authentication);
+				} else {
+					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다.");
+					return;
+				}
+			} catch (ExpiredJwtException e) {
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰이 만료되었습니다.");
+				return;
+			} catch (JwtException e) {
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+				return;
+			}
+		}
+	}
+
+	// 헤더에서 토큰 추출하는 메서드
+	private String extractTokenFromHeader(HttpServletRequest request) {
+		String beareToken = request.getHeader("Authorization");
+		if (beareToken != null && beareToken.startsWith("Bearer ")) {
+			return beareToken.substring(7);
+		}
+		return null;
+	}
+
+	// 쿠키에서 토큰 추출하는 메서드
+	private String extractTokenFromCookie(HttpServletRequest request) {
+		Cookie[] cookies = request.getCookies();
+		if (cookies != null) {
+			for (Cookie cookie : cookies) {
+				if ("accessToken".equals(cookie.getName())) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return null;
+	}
+
+	// Redis에서 토큰 블랙리스트 확인
+	private boolean isTokenBlacklisted(String token) {
+		return Boolean.TRUE.equals(redisTemplate.hasKey("blackList:" + token));
+	}
+
+	// Redis에 저장된 액세스 토큰과 일치하는지 확인
+	private boolean isTokenInRedis(String email, String token) {
+		String storedToken = redisTemplate.opsForValue().get("accessToken:" + email);
+		return token.equals(storedToken);
+	}
+
+}
+
+

--- a/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
@@ -37,9 +37,9 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
 		// 필터를 통과해야하는 엔드 포인트
 		return List.of(
-			"/api/*/auth/login",
-			"/api/*/auth/signup",
-			"/api/*/auth/refresh"
+			"/api/v1/auth/login",
+			"/api/v1/auth/signup",
+			"/api/v1/auth/refresh"
 		).contains(path);
 	}
 

--- a/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
@@ -69,12 +69,6 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 				String role = claims.get("role", String.class);
 				Boolean isVerified = claims.get("isEmailVerified", Boolean.class);
 
-				// Redis에 저장된 액세스 토큰과 일치하는지 확인
-				if (!isTokenInRedis(email, token)) {
-					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
-					return;
-				}
-
 				if (email != null && Boolean.TRUE.equals(isVerified)) {
 					// UserDetails 객체 생성 (DB에서 사용자 정보 조회)
 					UserDetails userDetails = userDetailsService.loadUserByUsername(email);
@@ -98,6 +92,8 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 				return;
 			}
 		}
+		// 검증 후 다음 필터로
+		filterChain.doFilter(request, response);
 	}
 
 	// 헤더에서 토큰 추출하는 메서드

--- a/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JWTAuthenticationFilter.java
@@ -30,6 +30,19 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
 	private final CustomUserDetailsService userDetailsService;
 	private final RedisTemplate<String, String> redisTemplate;
 
+	// 필터 체인 통과
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getServletPath();
+
+		// 필터를 통과해야하는 엔드 포인트
+		return List.of(
+			"/api/*/auth/login",
+			"/api/*/auth/signup",
+			"/api/*/auth/refresh"
+		).contains(path);
+	}
+
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {

--- a/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
@@ -36,13 +36,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String path = request.getServletPath();
+		String method = request.getMethod();
 
-		// 필터를 통과해야하는 엔드 포인트
-		return List.of(
+		// Auth 관련 엔드포인트 ⇒ 무조건 스킵
+		if (List.of(
 			"/api/v1/auth/login",
 			"/api/v1/auth/signup",
 			"/api/v1/auth/refresh"
-		).contains(path);
+		).contains(path)) {
+			return true;
+		}
+
+		// “댓글 쓰기·수정·삭제·좋아요” 만 필터 적용
+		boolean isCommentWriteEndpoint =
+			("POST".equals(method) && path.matches("^/api/v1/posts/\\d+/comments$"))            // 댓글 작성
+				|| ("PATCH".equals(method) && path.matches("^/api/v1/comments/\\d+$"))          // 댓글 수정
+				|| ("DELETE".equals(method) && path.matches("^/api/v1/comments/\\d+$"))         // 댓글 삭제
+				|| ("POST".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"));     // 댓글 좋아요
+
+		// isCommentWriteEndpoint 이면 필터 동작(= false 리턴), 아니면 스킵(= true 리턴)
+		return !isCommentWriteEndpoint;
 	}
 
 	@Override

--- a/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import io.jsonwebtoken.Claims;
@@ -23,8 +24,9 @@ import lombok.RequiredArgsConstructor;
 import site.kkokkio.global.security.CustomUserDetailsService;
 import site.kkokkio.global.util.JwtUtils;
 
+@Component
 @RequiredArgsConstructor
-public class JWTAuthenticationFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtUtils jwtUtils;
 	private final CustomUserDetailsService userDetailsService;

--- a/backend/src/main/java/site/kkokkio/global/security/CustomUserDetails.java
+++ b/backend/src/main/java/site/kkokkio/global/security/CustomUserDetails.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import site.kkokkio.domain.member.entity.Member;
+import site.kkokkio.global.enums.MemberRole;
 
 public class CustomUserDetails implements UserDetails {
 	private final Member member;
@@ -39,5 +40,23 @@ public class CustomUserDetails implements UserDetails {
 	@Override
 	public boolean isEnabled() {
 		return member.isEmailVerified();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		// 계정 만료 로직을 구현할 수 있으나, 현재는 항상 만료되지 않음으로 처리
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		// BLACK 역할인 경우 잠금 처리
+		return member.getRole() != MemberRole.BLACK;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		// 자격 증명(비밀번호) 만료 로직을 구현할 수 있으나, 현재는 항상 만료되지 않음으로 처리
+		return true;
 	}
 }

--- a/backend/src/main/java/site/kkokkio/global/security/CustomUserDetails.java
+++ b/backend/src/main/java/site/kkokkio/global/security/CustomUserDetails.java
@@ -1,0 +1,43 @@
+// 파일: src/main/java/site/kkokkio/global/security/CustomUserDetails.java
+package site.kkokkio.global.security;
+
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import site.kkokkio.domain.member.entity.Member;
+
+public class CustomUserDetails implements UserDetails {
+	private final Member member;
+
+	public CustomUserDetails(Member member) {
+		this.member = member;
+	}
+
+	/** 도메인 Member 객체를 외부에서 꺼내 쓸 때 사용합니다. */
+	public Member getMember() {
+		return member;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return AuthorityUtils.createAuthorityList(member.getRole().name());
+	}
+
+	@Override
+	public String getPassword() {
+		return member.getPasswordHash();
+	}
+
+	@Override
+	public String getUsername() {
+		return member.getEmail();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return member.isEmailVerified();
+	}
+}

--- a/backend/src/main/java/site/kkokkio/global/security/CustomUserDetailsService.java
+++ b/backend/src/main/java/site/kkokkio/global/security/CustomUserDetailsService.java
@@ -1,9 +1,5 @@
 package site.kkokkio.global.security;
 
-import java.util.List;
-
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -11,7 +7,6 @@ import org.springframework.stereotype.Service;
 
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.domain.member.repository.MemberRepository;
-import site.kkokkio.global.enums.MemberRole;
 
 @Service
 public class CustomUserDetailsService implements UserDetailsService {
@@ -27,23 +22,6 @@ public class CustomUserDetailsService implements UserDetailsService {
 		Member member = memberRepository.findByEmail(email)
 			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-		// MemberRole -> GrantedAuthority 매핑
-		List<SimpleGrantedAuthority> authorities = List.of(
-			new SimpleGrantedAuthority("ROLE_" + member.getRole().name())
-		);
-
-		// 계정 활성화 및 잠금 상태 설정
-		boolean enabled = member.isEmailVerified() && !member.isDeleted();
-		boolean accountNonLocked = member.getRole() != MemberRole.BLACK;
-
-		return new User(
-			member.getEmail(),
-			member.getPasswordHash(),
-			enabled,
-			true,
-			true,
-			accountNonLocked,
-			authorities
-		);
+		return new CustomUserDetails(member);
 	}
 }

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -44,6 +44,14 @@ public class JwtUtils {
 		return expiration;
 	}
 
+	// Claims 호출
+	public Claims getClaims(String token) {
+		return Jwts.parser()
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+
 	public Date getExpiration(String token) {
 		try {
 			SecretKey key = getSecretKey();
@@ -65,11 +73,12 @@ public class JwtUtils {
 	}
 
 	// JWT 생성
-	public String createToken(Map<String, Object> claims) {
+	public String createToken(String email, Map<String, Object> claims) {
 		SecretKey key = getSecretKey();
 		Date issuedAt = new Date();
 
 		return Jwts.builder()
+			.subject(email) // 사용자 식별자(email)
 			.claims(claims) // 사용자 정보 포함
 			.issuedAt(issuedAt) // 발급 시간
 			.expiration(new Date(issuedAt.getTime() + expiration)) // 만료 시간
@@ -78,11 +87,12 @@ public class JwtUtils {
 	}
 
 	// 리프레시 토큰 생성
-	public String createRefreshToken(Map<String, Object> claims) {
+	public String createRefreshToken(String email, Map<String, Object> claims) {
 		SecretKey key = getSecretKey();
 		Date issuedAt = new Date();
 
 		return Jwts.builder()
+			.subject(email)
 			.claims(claims)
 			.issuedAt(issuedAt)
 			.expiration(new Date(issuedAt.getTime() + refreshTokenExpiration))

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -123,7 +123,7 @@ public class JwtUtils {
 
 	//JWT -> 쿠키에 저장
 	public void setJwtInCookie(String token, HttpServletResponse response) {
-		ResponseCookie cookie = ResponseCookie.from("access-token", token)
+		ResponseCookie cookie = ResponseCookie.from("accessToken", token)
 			.httpOnly(true) // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/") // 전체 사이트에서 접근 가능
 
@@ -139,7 +139,7 @@ public class JwtUtils {
 
 	// 리프레시 토큰을 쿠키에 저장
 	public void setRefreshTokenInCookie(String token, HttpServletResponse response) {
-		ResponseCookie cookie = ResponseCookie.from("refresh_token", token)
+		ResponseCookie cookie = ResponseCookie.from("refreshToken", token)
 			.httpOnly(true)     // 자바스크립트 접근 차단 (XSS 방지)
 			.path("/auth")      // 인증 경로에서만 접근 가능
 
@@ -165,7 +165,7 @@ public class JwtUtils {
 			.forEach(cookie -> log.info("Cookie Name: {}, Value: {}", cookie.getName(), cookie.getValue()));
 
 		return Arrays.stream(cookies)
-			.filter(cookie -> "access-token".equals(cookie.getName()))
+			.filter(cookie -> "accessToken".equals(cookie.getName()))
 			.map(Cookie::getValue)
 			.findFirst();
 	}
@@ -179,7 +179,7 @@ public class JwtUtils {
 		}
 
 		return Arrays.stream(cookies)
-			.filter(cookie -> "refresh_token".equals(cookie.getName()))
+			.filter(cookie -> "refreshToken".equals(cookie.getName()))
 			.map(Cookie::getValue)
 			.findFirst();
 	}
@@ -187,7 +187,7 @@ public class JwtUtils {
 	// 쿠키 삭제 (로그아웃 시 사용)
 	public void clearAuthCookies(HttpServletResponse response) {
 		// 액세스 토큰 쿠키 삭제
-		ResponseCookie accessCookie = ResponseCookie.from("access-token", "")
+		ResponseCookie accessCookie = ResponseCookie.from("accessToken", "")
 			.httpOnly(true)
 			.path("/")
 			.maxAge(0) // 즉시 만료
@@ -196,7 +196,7 @@ public class JwtUtils {
 			.build();
 
 		// 리프레시 토큰 쿠키 삭제
-		ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", "")
+		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", "")
 			.httpOnly(true)
 			.path("/auth")
 			.maxAge(0) // 즉시 만료

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -46,7 +46,9 @@ public class JwtUtils {
 
 	// Claims 호출
 	public Claims getClaims(String token) {
+		SecretKey key = getSecretKey();
 		return Jwts.parser()
+			.verifyWith(key)
 			.build()
 			.parseSignedClaims(token)
 			.getPayload();

--- a/backend/src/test/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1Test.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -20,6 +21,8 @@ import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyDto;
 import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.security.CustomUserDetailsService;
+import site.kkokkio.global.util.JwtUtils;
 
 @WebMvcTest(controllers = KeywordMetricHourlyControllerV1.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -29,6 +32,15 @@ public class KeywordMetricHourlyControllerV1Test {
 
 	@MockitoBean
 	private KeywordMetricHourlyService keywordMetricHourlyService;
+
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
+
+	@MockitoBean
+	private RedisTemplate<String, String> redisTemplate;
+
+	@MockitoBean
+	private JwtUtils jwtUtils;
 
 	@Test
 	@DisplayName("인기 10 키워드 조회 - 성공")
@@ -56,7 +68,8 @@ public class KeywordMetricHourlyControllerV1Test {
 	@Test
 	@DisplayName("인기 10 키워드 조회 - 잘못된 요청")
 	public void getKeywordMetricHourly_Fail() throws Exception {
-		given(keywordMetricHourlyService.findHourlyMetrics()).willThrow(new ServiceException("404", "키워드를 불러오지 못했습니다."));
+		given(keywordMetricHourlyService.findHourlyMetrics()).willThrow(
+			new ServiceException("404", "키워드를 불러오지 못했습니다."));
 
 		mvc.perform(get("/api/v1/keywords/top"))
 			.andExpect(status().isOk())

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/AuthControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/AuthControllerV1Test.java
@@ -12,7 +12,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,9 +28,11 @@ import site.kkokkio.domain.member.service.MemberService;
 import site.kkokkio.global.aspect.ResponseAspect;
 import site.kkokkio.global.enums.MemberRole;
 import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.security.CustomUserDetailsService;
 import site.kkokkio.global.util.JwtUtils;
 
 @WebMvcTest(AuthControllerV1.class)
+@ActiveProfiles("test")
 @AutoConfigureMockMvc(addFilters = false)
 @Import(ResponseAspect.class)               // ① AOP 빈 등록
 @EnableAspectJAutoProxy(proxyTargetClass = true)
@@ -48,6 +52,12 @@ public class AuthControllerV1Test {
 
 	@MockitoBean
 	private AuthService authService;
+
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
+
+	@MockitoBean
+	private RedisTemplate<String, String> redisTemplate;
 
 	@Test
 	@DisplayName("로그인 - 성공")

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
@@ -14,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -27,6 +28,7 @@ import site.kkokkio.domain.member.service.MemberService;
 import site.kkokkio.global.aspect.ResponseAspect;
 import site.kkokkio.global.enums.MemberRole;
 import site.kkokkio.global.exception.CustomAuthException;
+import site.kkokkio.global.security.CustomUserDetailsService;
 import site.kkokkio.global.util.JwtUtils;
 
 @WebMvcTest(MemberControllerV1.class)
@@ -49,6 +51,12 @@ class MemberControllerV1Test {
 
 	@MockitoBean
 	private AuthService authService;
+
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
+
+	@MockitoBean
+	private RedisTemplate<String, String> redisTemplate;
 
 	@Test
 	@DisplayName("회원가입 - 성공")

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -156,6 +156,7 @@ class AuthServiceV1Test {
 		given(claims.get("email", String.class)).willReturn(email);
 
 		given(jwtUtils.getJwtFromCookies(request)).willReturn(Optional.of(at));
+		given(jwtUtils.getClaims(at)).willReturn(claims);
 		given(jwtUtils.getPayload(at)).willReturn(claims);
 		given(jwtUtils.getExpiration(at)).willReturn(new Date(System.currentTimeMillis() + 60000));
 

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -95,23 +95,22 @@ class AuthServiceV1Test {
 		// given
 		given(memberService.findByEmail(email)).willReturn(member);
 		given(passwordEncoder.matches(rawPw, encPw)).willReturn(true);
-		given(jwtUtils.createToken(anyMap())).willReturn("access-token");
-		given(jwtUtils.createRefreshToken(anyMap())).willReturn("refresh-token");
+		given(jwtUtils.createToken(anyMap())).willReturn("accessToken");
+		given(jwtUtils.createRefreshToken(anyMap())).willReturn("refreshToken");
 		willDoNothing().given(valueOperations)
-			.set(eq("RT:" + email), eq("refresh-token"), any(Duration.class));
+			.set(eq("refreshToken:" + email), eq("refreshToken"), any(Duration.class));
 
 		// 쿠키 저장 stub
-		willDoNothing().given(jwtUtils).setJwtInCookie(eq("access-token"), any());
-		willDoNothing().given(jwtUtils).setRefreshTokenInCookie(eq("refresh-token"), any());
+		willDoNothing().given(jwtUtils).setJwtInCookie(eq("accessToken"), any());
+		willDoNothing().given(jwtUtils).setRefreshTokenInCookie(eq("refreshToken"), any());
 
-		// when
 		// when
 		MemberLoginResponse result = authService.login(email, rawPw, response);
 
 		// then
 		assertThat(result.email()).isEqualTo(email);
-		assertThat(result.token()).isEqualTo("access-token");
-		assertThat(result.refreshToken()).isEqualTo("refresh-token");
+		assertThat(result.token()).isEqualTo("accessToken");
+		assertThat(result.refreshToken()).isEqualTo("refreshToken");
 	}
 
 	@Test
@@ -141,7 +140,7 @@ class AuthServiceV1Test {
 
 		given(jwtUtils.getRefreshTokenFromCookies(request)).willReturn(Optional.of(rt));
 		given(jwtUtils.getPayload(rt)).willReturn(claims);
-		given(valueOperations.get("RT:" + email)).willReturn(rt);
+		given(valueOperations.get("refreshToken:" + email)).willReturn(rt);
 		given(jwtUtils.createToken(claims)).willReturn("new-access");
 
 		TokenDto result = authService.refreshToken(request, response);
@@ -165,7 +164,7 @@ class AuthServiceV1Test {
 
 		willDoNothing().given(valueOperations)
 			.set(eq("BL:" + at), eq("logout"), any(Duration.class));
-		given(redisTemplate.delete("RT:" + email)).willReturn(true);
+		given(redisTemplate.delete("refreshToken:" + email)).willReturn(true);
 		willDoNothing().given(jwtUtils).clearAuthCookies(response);
 
 		// when & then

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -7,7 +7,6 @@ import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -86,17 +85,15 @@ class AuthServiceV1Test {
 
 		// Claims
 		Map<String, Object> claims = Map.of(
-			"id", UUID.randomUUID(),
-			"email", email,
-			"nickname", "nick",
+			"isEmailVerified", true,
 			"role", MemberRole.USER
 		);
 
 		// given
 		given(memberService.findByEmail(email)).willReturn(member);
 		given(passwordEncoder.matches(rawPw, encPw)).willReturn(true);
-		given(jwtUtils.createToken(anyMap())).willReturn("accessToken");
-		given(jwtUtils.createRefreshToken(anyMap())).willReturn("refreshToken");
+		given(jwtUtils.createToken(eq(email), anyMap())).willReturn("accessToken");
+		given(jwtUtils.createRefreshToken(eq(email), anyMap())).willReturn("refreshToken");
 		willDoNothing().given(valueOperations)
 			.set(eq("refreshToken:" + email), eq("refreshToken"), any(Duration.class));
 
@@ -141,7 +138,7 @@ class AuthServiceV1Test {
 		given(jwtUtils.getRefreshTokenFromCookies(request)).willReturn(Optional.of(rt));
 		given(jwtUtils.getPayload(rt)).willReturn(claims);
 		given(valueOperations.get("refreshToken:" + email)).willReturn(rt);
-		given(jwtUtils.createToken(claims)).willReturn("new-access");
+		given(jwtUtils.createToken(email, claims)).willReturn("new-access");
 
 		TokenDto result = authService.refreshToken(request, response);
 

--- a/backend/src/test/java/site/kkokkio/domain/post/controller/PostControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/post/controller/PostControllerV1Test.java
@@ -11,12 +11,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import site.kkokkio.domain.post.dto.PostDto;
 import site.kkokkio.domain.post.service.PostService;
 import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.security.CustomUserDetailsService;
+import site.kkokkio.global.util.JwtUtils;
 
 @WebMvcTest(PostControllerV1.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -27,6 +30,15 @@ public class PostControllerV1Test {
 
 	@MockitoBean
 	private PostService postService;
+
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
+
+	@MockitoBean
+	private RedisTemplate<String, String> redisTemplate;
+
+	@MockitoBean
+	private JwtUtils jwtUtils;
 
 	@Test
 	@DisplayName("포스트 단건 조회 - 성공")

--- a/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -27,331 +28,353 @@ import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.security.CustomUserDetailsService;
+import site.kkokkio.global.util.JwtUtils;
 
 @WebMvcTest(controllers = SourceControllerV1.class)
 @AutoConfigureMockMvc(addFilters = false)
 class SourceControllerV1Test {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @MockitoBean
-    private SourceService sourceService;
+	@MockitoBean
+	private SourceService sourceService;
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 성공")
-    void getNewsSources_Success() throws Exception {
-        // given
-        List<SourceDto> mockNewsList = List.of(
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS),
-                new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.NAVER_NEWS)
-        );
-        given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(mockNewsList);
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-                .andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
-                .andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
-    }
+	@MockitoBean
+	private RedisTemplate<String, String> redisTemplate;
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 데이터 없음")
-    void getNewsSources_EmptyList() throws Exception {
-        // given
-        given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(List.of());
+	@MockitoBean
+	private JwtUtils jwtUtils;
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-                .andExpect(jsonPath("$.data.list").isEmpty());
-    }
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 성공")
+	void getNewsSources_Success() throws Exception {
+		// given
+		List<SourceDto> mockNewsList = List.of(
+			new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS)
+		);
+		given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(mockNewsList);
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 잘못된 요청")
-    void getNewsSources_InvalidPostId_BadRequest() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", "invalidId"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+			.andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
+			.andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
+	}
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 포스트 없음")
-    void getNewsSources_PostNotFound() throws Exception {
-        // given
-        given(sourceService.getTop10NewsSourcesByPostId(anyLong()))
-                .willThrow(new ServiceException("404", "해당 포스트를 찾을 수 없습니다."));
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 데이터 없음")
+	void getNewsSources_EmptyList() throws Exception {
+		// given
+		given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(List.of());
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", 999L))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("404"))
-                .andExpect(jsonPath("$.message").value("해당 포스트를 찾을 수 없습니다."));
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+			.andExpect(jsonPath("$.data.list").isEmpty());
+	}
 
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 잘못된 요청")
+	void getNewsSources_InvalidPostId_BadRequest() throws Exception {
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", "invalidId"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400"))
+			.andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+	}
 
-    @Test
-    @DisplayName("포스트의 출처 영상 조회 - 성공")
-    void getVideoSources_Success() throws Exception {
-        // given
-        List<SourceDto> mockVideoList = List.of(
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목1", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목2", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목3", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목4", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목5", LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE)
-        );
-        given(sourceService.getTop10VideoSourcesByPostId(anyLong())).willReturn(mockVideoList);
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 포스트 없음")
+	void getNewsSources_PostNotFound() throws Exception {
+		// given
+		given(sourceService.getTop10NewsSourcesByPostId(anyLong()))
+			.willThrow(new ServiceException("404", "해당 포스트를 찾을 수 없습니다."));
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/videos", 1L))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-                .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
-                .andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", 999L))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("404"))
+			.andExpect(jsonPath("$.message").value("해당 포스트를 찾을 수 없습니다."));
+	}
 
-    @Test
-    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
-    void getTopYoutubeSources_Success() throws Exception {
+	@Test
+	@DisplayName("포스트의 출처 영상 조회 - 성공")
+	void getVideoSources_Success() throws Exception {
+		// given
+		List<SourceDto> mockVideoList = List.of(
+			new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목1",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목2",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목3",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목4",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("https://youtube.com", "https://image.jpg", "영상 제목5",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE)
+		);
+		given(sourceService.getTop10VideoSourcesByPostId(anyLong())).willReturn(mockVideoList);
 
-        /// given
-        // Mocking 할 서비스 메소드의 반환 값 생성
-        List<TopSourceItemDto> mockItemList = List.of(
-                TopSourceItemDto.builder()
-                        .url("https://youtube.com/watch?v=video1")
-                        .title("유튜브 인기 영상 제목 1")
-                        .thumbnailUrl("https://image.youtube1.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
-                        .platform(Platform.YOUTUBE)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .url("https://youtube.com/watch?v=video2")
-                        .title("유튜브 인기 영상 제목 2")
-                        .thumbnailUrl("https://image.youtube2.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
-                        .platform(Platform.YOUTUBE)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .url("https://youtube.com/watch?v=video3")
-                        .title("유튜브 인기 영상 제목 3")
-                        .thumbnailUrl("https://image.youtube3.jpg")
-                        .publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
-                        .platform(Platform.YOUTUBE)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .url("https://youtube.com/watch?v=video4")
-                        .title("유튜브 인기 영상 제목 4")
-                        .thumbnailUrl("https://image.youtube4.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
-                        .platform(Platform.YOUTUBE)
-                        .build()
-        );
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/videos", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+			.andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
+			.andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
+	}
 
-        // Mocking할 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, 100);
+	@Test
+	@DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
+	void getTopYoutubeSources_Success() throws Exception {
 
-        // Mocking할 최종 반환 객체 TopSourceListResponse 생성
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
+		/// given
+		// Mocking 할 서비스 메소드의 반환 값 생성
+		List<TopSourceItemDto> mockItemList = List.of(
+			TopSourceItemDto.builder()
+				.url("https://youtube.com/watch?v=video1")
+				.title("유튜브 인기 영상 제목 1")
+				.thumbnailUrl("https://image.youtube1.jpg")
+				.publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
+				.platform(Platform.YOUTUBE)
+				.build(),
+			TopSourceItemDto.builder()
+				.url("https://youtube.com/watch?v=video2")
+				.title("유튜브 인기 영상 제목 2")
+				.thumbnailUrl("https://image.youtube2.jpg")
+				.publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
+				.platform(Platform.YOUTUBE)
+				.build(),
+			TopSourceItemDto.builder()
+				.url("https://youtube.com/watch?v=video3")
+				.title("유튜브 인기 영상 제목 3")
+				.thumbnailUrl("https://image.youtube3.jpg")
+				.publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
+				.platform(Platform.YOUTUBE)
+				.build(),
+			TopSourceItemDto.builder()
+				.url("https://youtube.com/watch?v=video4")
+				.title("유튜브 인기 영상 제목 4")
+				.thumbnailUrl("https://image.youtube4.jpg")
+				.publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
+				.platform(Platform.YOUTUBE)
+				.build()
+		);
 
-        // sousourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopYoutubeSources(any(Pageable.class)))
-                .willReturn(mockResponse);
+		// Mocking할 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, 100);
 
-        /// when & then
-        // /api/v1/videos/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/videos/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
-                .andExpect(jsonPath("$.data.meta").exists())
-                
-                // 첫번째 값 검증
-                .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
-                .andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.youtube1.jpg"))
-                .andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
-                .andExpect(jsonPath("$.data.list[0].platform").value("YOUTUBE"))
-                
-                // data.meta 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
-    }
+		// Mocking할 최종 반환 객체 TopSourceListResponse 생성
+		TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
 
-    @Test
-    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 데이터 없음")
-    void getTopYoutubeSources_EmptyList() throws Exception {
+		// sousourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopYoutubeSources(any(Pageable.class)))
+			.willReturn(mockResponse);
 
-        /// given
-        // Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
+		/// when & then
+		// /api/v1/videos/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/videos/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        // Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
+			// 첫번째 값 검증
+			.andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
+			.andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.youtube1.jpg"))
+			.andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
+			.andExpect(jsonPath("$.data.list[0].platform").value("YOUTUBE"))
 
-        // sourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopYoutubeSources(any(Pageable.class))).willReturn(mockResponse);
+			// data.meta 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
+	}
 
-        /// when & then
-        // /api/v1/videos/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/videos/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list").isEmpty())
-                .andExpect(jsonPath("$.data.meta").exists())
+	@Test
+	@DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 데이터 없음")
+	void getTopYoutubeSources_EmptyList() throws Exception {
 
-                // data.met 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));;
-    }
+		/// given
+		// Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
 
-    @Test
-    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
-    void getTopNaverNewsSources_Success() throws Exception {
+		// Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
+		TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
 
-        /// given
-        // Mocking 할 서비스 메소드의 반환 값 생성
-        List<TopSourceItemDto> mockItemList = List.of(
-                TopSourceItemDto.builder()
-                        .url("https://news.naver.com/article/1")
-                        .title("네이버 인기 뉴스 제목 1")
-                        .thumbnailUrl("https://image.naver.com/1.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .url("https://news.naver.com/article/2")
-                        .title("네이버 인기 뉴스 제목 2")
-                        .thumbnailUrl("https://image.naver.com/2.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .url("https://news.naver.com/article/3")
-                        .title("네이버 인기 뉴스 제목 3")
-                        .thumbnailUrl("https://image.naver.com/3.jpg")
-                        .publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .url("https://news.naver.com/article/4")
-                        .title("네이버 인기 뉴스 제목 4")
-                        .thumbnailUrl("https://image.naver.com/4.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build()
-        );
+		// sourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopYoutubeSources(any(Pageable.class))).willReturn(mockResponse);
 
-        // Mocking할 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, 100);
+		/// when & then
+		// /api/v1/videos/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/videos/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list").isEmpty())
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        // Mocking할 최종 반환 객체 TopSourceListResponse 생성
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
+			// data.met 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));
+		;
+	}
 
-        // sousourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopNaverNewsSources(any(Pageable.class)))
-                .willReturn(mockResponse);
+	@Test
+	@DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
+	void getTopNaverNewsSources_Success() throws Exception {
 
-        /// when & then
-        // /api/v1/news/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/news/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
-                .andExpect(jsonPath("$.data.meta").exists())
+		/// given
+		// Mocking 할 서비스 메소드의 반환 값 생성
+		List<TopSourceItemDto> mockItemList = List.of(
+			TopSourceItemDto.builder()
+				.url("https://news.naver.com/article/1")
+				.title("네이버 인기 뉴스 제목 1")
+				.thumbnailUrl("https://image.naver.com/1.jpg")
+				.publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
+				.platform(Platform.NAVER_NEWS)
+				.build(),
+			TopSourceItemDto.builder()
+				.url("https://news.naver.com/article/2")
+				.title("네이버 인기 뉴스 제목 2")
+				.thumbnailUrl("https://image.naver.com/2.jpg")
+				.publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
+				.platform(Platform.NAVER_NEWS)
+				.build(),
+			TopSourceItemDto.builder()
+				.url("https://news.naver.com/article/3")
+				.title("네이버 인기 뉴스 제목 3")
+				.thumbnailUrl("https://image.naver.com/3.jpg")
+				.publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
+				.platform(Platform.NAVER_NEWS)
+				.build(),
+			TopSourceItemDto.builder()
+				.url("https://news.naver.com/article/4")
+				.title("네이버 인기 뉴스 제목 4")
+				.thumbnailUrl("https://image.naver.com/4.jpg")
+				.publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
+				.platform(Platform.NAVER_NEWS)
+				.build()
+		);
 
-                // 첫번째 값 검증
-                .andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
-                .andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.naver.com/1.jpg"))
-                .andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
-                .andExpect(jsonPath("$.data.list[0].platform").value("NAVER_NEWS"))
+		// Mocking할 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, 100);
 
-                // data.meta 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
-    }
+		// Mocking할 최종 반환 객체 TopSourceListResponse 생성
+		TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
 
-    @Test
-    @DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 데이터 없음")
-    void getTopNaverNewsSources_EmptyList() throws Exception {
+		// sousourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopNaverNewsSources(any(Pageable.class)))
+			.willReturn(mockResponse);
 
-        /// given
-        // Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
+		/// when & then
+		// /api/v1/news/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/news/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        // Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
+			// 첫번째 값 검증
+			.andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
+			.andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.naver.com/1.jpg"))
+			.andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
+			.andExpect(jsonPath("$.data.list[0].platform").value("NAVER_NEWS"))
 
-        // sourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopNaverNewsSources(any(Pageable.class))).willReturn(mockResponse);
+			// data.meta 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
+	}
 
-        /// when & then
-        // /api/v1/news/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/news/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list").isEmpty())
-                .andExpect(jsonPath("$.data.meta").exists())
+	@Test
+	@DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 데이터 없음")
+	void getTopNaverNewsSources_EmptyList() throws Exception {
 
-                // data.met 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));;
-    }
+		/// given
+		// Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
+
+		// Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
+		TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
+
+		// sourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopNaverNewsSources(any(Pageable.class))).willReturn(mockResponse);
+
+		/// when & then
+		// /api/v1/news/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/news/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list").isEmpty())
+			.andExpect(jsonPath("$.data.meta").exists())
+
+			// data.met 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));
+		;
+	}
 }


### PR DESCRIPTION
## 연관된 이슈

> ex) #80 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- access-token, refresh_token -> accessToken, refreshToken(기존에 통일 되어 있지 않던 토큰 네이밍 카멜 케이스로 전부 변경)
- toekn 사용자 식별자 email 적용
- JwtAuthenticationFilter 생성
- CustomUserDetails, CustomUserDetailService 생성 및 리펙토링
- CommentControllerV1 CustomUserDetails 구현체 적용
- SecurityConfig에 JwtAuthenticationFilter 적용
- 로그인 관련 예외 처리 추가
- 로그인 한 회원만 댓글 작성, 수정, 삭제, 좋아요 접근 권한 허용, 그외 모든 요청 허용

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- 기존 쿠키를 발행할 때 Token명이 accees-token, refresh_token 등 통일 되지 않은 네이밍으로 발행되어 있는 문제가 있어 전부 카멜케이스로 적용해두었습니다.-> accessToken, refreshToken(프론트 엔드 개발자님께 해당내용 전달 필수)
- test 통과를 위해 controllerTest에 필요한 CustomUserDetailsService, RedisTemplate<String, String>, JwtUtils 에 대한 MockitoBean 주입 했습니다.
- 생각보다 작업이 오래 걸리게 되어 죄송합니다. PR 크기가 커져서 중간에 끊고 올릴까도 생각했지만, 인가가 잘못되서 다른 API엔드포인트가 막혀 문제가 생길까봐 최대한 꼼꼼하게 확인 후 commit 하였습니다. 추후 문제가 발생되는 API 엔드 포인트가 있다면 말씀해주시길 바랍니다.
closes #80