### PR TITLE
build: 프로덕션 서버와 개발 서버 분리

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -23,6 +23,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v-dev-
 
       - name: Create Release
         id: create_release
@@ -31,7 +32,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.create_tag.outputs.new_tag }}
-          release_name: Release ${{ steps.create_tag.outputs.new_tag }}
+          release_name: DEV Release ${{ steps.create_tag.outputs.new_tag }}
           body: ${{ steps.create_tag.outputs.changelog }}
           draft: false
           prerelease: false
@@ -64,7 +65,7 @@ jobs:
 
       - name: export image name
         id: export_image
-        run: echo "image_name=team04-kkokkio" >> $GITHUB_OUTPUT
+        run: echo "image_name=team04-kkokkio-dev" >> $GITHUB_OUTPUT
 
       - name: 빌드 앤 푸시
         uses: docker/build-push-action@v3
@@ -93,7 +94,7 @@ jobs:
         id: get_instance_id
         run: |
           INSTANCE_ID=$(aws ec2 describe-instances \
-            --filters "Name=tag:Name,Values=team04-kkokkio" "Name=instance-state-name,Values=running" \
+            --filters "Name=tag:Name,Values=team04-kkokkio" "Name=tag:env,Values=dev" "Name=instance-state-name,Values=running" \
             --query "Reservations[].Instances[].InstanceId" --output text)
           echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
 
@@ -115,6 +116,6 @@ jobs:
             docker pull ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
             docker stop app1 2>/dev/null || true && \
             docker rm app1 2>/dev/null || true && \
-            docker run --restart always -e DOPPLER_TOKEN=${{ secrets.DOPPLER_SERVICE_TOKEN }} -d --name app1 -p 8080:8080 --network common \
+            docker run --restart always -e DOPPLER_TOKEN=${{ secrets.DOPPLER_DEV_SERVICE_TOKEN }} -d --name app1 -p 8080:8080 --network common \
             ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
             docker rmi $(docker images -f "dangling=true" -q) || true

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -1,0 +1,122 @@
+name: deploy-develop
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - 'backend/src/**'
+      - 'backend/build.gradle'
+      - 'backend/settings.gradle'
+      - 'backend/Dockerfile'
+    branches:
+      #     TODO:첫 병합 후 develop에서 main으로 변경할 것
+      - develop
+jobs:
+  makeTagAndRelease:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.create_tag.outputs.new_tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Tag
+        id: create_tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v-prd-
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.create_tag.outputs.new_tag }}
+          release_name: PRD Release ${{ steps.create_tag.outputs.new_tag }}
+          body: ${{ steps.create_tag.outputs.changelog }}
+          draft: false
+          prerelease: false
+
+  buildImageAndPush:
+    name: 도커 이미지 빌드와 푸시
+    needs: makeTagAndRelease
+    runs-on: ubuntu-latest
+    outputs:
+      owner_lc: ${{ steps.export_owner.outputs.owner_lc }}
+      image_name: ${{ steps.export_image.outputs.image_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Buildx 설치
+        uses: docker/setup-buildx-action@v2
+
+      - name: 레지스트리 로그인
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set lower case owner name
+        id: export_owner
+        run: |
+          OWNER_LC="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "owner_lc=$OWNER_LC" >> $GITHUB_OUTPUT
+
+      - name: export image name
+        id: export_image
+        run: echo "image_name=team04-kkokkio-prd" >> $GITHUB_OUTPUT
+
+      - name: 빌드 앤 푸시
+        uses: docker/build-push-action@v3
+        with:
+          context: backend
+          push: true
+          cache-from: type=registry,ref=ghcr.io/${{ steps.export_owner.outputs.owner_lc }}/${{ steps.export_image.outputs.image_name }}:cache
+          cache-to: type=registry,ref=ghcr.io/${{ steps.export_owner.outputs.owner_lc }}/${{ steps.export_image.outputs.image_name }}:cache,mode=max
+          tags: |
+            ghcr.io/${{ steps.export_owner.outputs.owner_lc }}/${{ steps.export_image.outputs.image_name }}:${{ needs.makeTagAndRelease.outputs.tag_name }},
+            ghcr.io/${{ steps.export_owner.outputs.owner_lc }}/${{ steps.export_image.outputs.image_name }}:latest
+
+  deploy:
+    name: EC2에 배포
+    runs-on: ubuntu-latest
+    needs: [ buildImageAndPush ]
+    steps:
+      - name: AWS Credentials 설정 (GitHub secrets 사용)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: 인스턴스 ID 가져오기
+        id: get_instance_id
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=team04-kkokkio" "Name=tag:env,Values=prd" "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId" --output text)
+          echo "INSTANCE_ID=$INSTANCE_ID" >> $GITHUB_ENV
+
+      - name: AWS SSM Send-Command
+        uses: peterkimzz/aws-ssm-send-command@master
+        id: ssm
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          instance-ids: ${{ env.INSTANCE_ID }}
+          working-directory: /
+          comment: Deploy
+          command: |
+            set -e
+            export HOME=/root
+            echo "${{ secrets.TK_GITHUB_ACCESS_TOKEN }}" | docker login ghcr.io -u ${{ secrets.TK_GITHUB_ACCESS_TOKEN_OWNER }} --password-stdin
+            
+            docker pull ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
+            docker stop app1 2>/dev/null || true && \
+            docker rm app1 2>/dev/null || true && \
+            docker run --restart always -e DOPPLER_TOKEN=${{ secrets.DOPPLER_PRD_SERVICE_TOKEN }} -d --name app1 -p 8080:8080 --network common \
+            ghcr.io/${{ needs.buildImageAndPush.outputs.owner_lc }}/${{ needs.buildImageAndPush.outputs.image_name }}:latest && \
+            docker rmi $(docker images -f "dangling=true" -q) || true

--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,21 @@
 
 **/mysql_logs/
 
-### custom ###
-infra/.terraform.lock.hcl
-/infra/.terraform
-/infra/terraform.lock.hcl
-/infra/terraform.tfstate
-/infra/terraform.tfstate.backup
+### infra custom ###
 /infra/secrets.tf
-/infra/.env
+
+/infra/dev/.terraform
+/infra/dev/.turbo
+/infra/dev/terraform.lock.hcl
+/infra/dev/terraform.tfstate
+/infra/dev/terraform.tfstate.backup
+/infra/dev/.env
+infra/dev/.terraform.lock.hcl
+
+/infra/prd/.terraform
+/infra/prd/.turbo
+/infra/prd/terraform.lock.hcl
+/infra/prd/terraform.tfstate
+/infra/prd/terraform.tfstate.backup
+/infra/prd/.env
+infra/prd/.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 ### infra custom ###
 /infra/secrets.tf
 
-/infra/dev/.terraform
+/infra/**/.terraform
+
 /infra/dev/.turbo
 /infra/dev/terraform.lock.hcl
 /infra/dev/terraform.tfstate
@@ -18,7 +19,6 @@
 /infra/dev/.env
 infra/dev/.terraform.lock.hcl
 
-/infra/prd/.terraform
 /infra/prd/.turbo
 /infra/prd/terraform.lock.hcl
 /infra/prd/terraform.tfstate

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -2,6 +2,11 @@ setup:
   - project: kkokkio-backend
     config: local
     path: backend
+
   - project: kkokkio-infra
     config: dev
-    path: infra
+    path: infra/dev
+
+  - project: kkokkio-infra
+    config: prd
+    path: infra/prd

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -1,0 +1,396 @@
+terraform {
+  // aws 라이브러리 불러옴
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+# AWS 설정 시작
+provider "aws" {
+  region = var.region
+}
+# AWS 설정 끝
+
+# VPC 설정 시작
+resource "aws_vpc" "vpc_1" {
+  cidr_block = "10.0.0.0/16"
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    ResourceName = "${var.prefix}-vpc-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+  }
+}
+
+resource "aws_subnet" "subnet_1" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+}
+
+resource "aws_subnet" "subnet_2" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "${var.region}b"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-2"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+}
+
+resource "aws_subnet" "subnet_3" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.3.0/24"
+  availability_zone       = "${var.region}c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-3"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+}
+
+resource "aws_subnet" "subnet_4" {
+  vpc_id                  = aws_vpc.vpc_1.id
+  cidr_block              = "10.0.4.0/24"
+  availability_zone       = "${var.region}d"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-4"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+}
+
+resource "aws_internet_gateway" "igw_1" {
+  vpc_id = aws_vpc.vpc_1.id
+
+  tags = {
+    ResourceName = "${var.prefix}-igw-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+  }
+}
+
+resource "aws_route_table" "rt_1" {
+  vpc_id = aws_vpc.vpc_1.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw_1.id
+  }
+
+  tags = {
+    ResourceName = "${var.prefix}-rt-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+}
+
+resource "aws_route_table_association" "association_1" {
+  subnet_id      = aws_subnet.subnet_1.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_2" {
+  subnet_id      = aws_subnet.subnet_2.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_3" {
+  subnet_id      = aws_subnet.subnet_3.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_4" {
+  subnet_id      = aws_subnet.subnet_4.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_security_group" "sg_1" {
+  name   = "${var.prefix}-sg-1"
+  vpc_id = aws_vpc.vpc_1.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 81
+    to_port   = 81
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+    self      = true
+  }
+
+  ingress {
+    from_port = 6379
+    to_port   = 6379
+    protocol  = "tcp"
+    self      = true
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    ResourceName = "${var.prefix}-sg-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+}
+
+# EC2 설정 시작
+
+# EC2 역할 생성
+resource "aws_iam_role" "ec2_role_1" {
+  name = "${var.prefix}-ec2-role-1"
+
+  # 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
+  assume_role_policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Action": "sts:AssumeRole",
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow"
+      }
+    ]
+  }
+  EOF
+}
+
+# EC2 역할에 AmazonS3FullAccess 정책을 부착
+resource "aws_iam_role_policy_attachment" "s3_full_access" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+# EC2 역할에 AmazonEC2RoleforSSM 정책을 부착
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+# IAM 인스턴스 프로파일 생성
+resource "aws_iam_instance_profile" "instance_profile_1" {
+  name = "${var.prefix}-instance-profile-1"
+  role = aws_iam_role.ec2_role_1.name
+}
+
+locals {
+  ec2_user_data_base = <<-END_OF_FILE
+#!/bin/bash
+# 가상 메모리 4GB 설정
+sudo dd if=/dev/zero of=/swapfile bs=128M count=32
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+sudo sh -c 'echo "/swapfile swap swap defaults 0 0" >> /etc/fstab'
+
+# 도커 설치 및 실행/활성화
+yum install docker -y
+systemctl enable docker
+systemctl start docker
+
+# gnupg2 설치 (doppler CLI용)
+yum install -y --allowerasing gnupg2
+
+# 도플러 CLI 설치
+curl -Ls https://cli.doppler.com/install.sh | sudo DOPPLER_INSTALL_DIR=/usr/local/bin sh
+
+# 도커 네트워크 생성
+docker network create common
+
+# nginx-proxy-manager
+docker run -d \
+  --name npm_1 \
+  --restart unless-stopped \
+  --network common \
+  -p 80:80 \
+  -p 443:443 \
+  -p 81:81 \
+  -e TZ=Asia/Seoul \
+  -v /dockerProjects/npm_1/volumes/data:/data \
+  -v /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt \
+  jc21/nginx-proxy-manager:latest
+
+# redis 컨테이너 (도커컴포즈 맞춤)
+docker run -d \
+  --name redis \
+  --restart always \
+  --network common \
+  -p 6379:6379 \
+  -v /dockerProjects/redis_data:/data \
+  -e TZ=Asia/Seoul \
+  redis:alpine
+
+# mysql 컨테이너 (도커컴포즈 맞춤)
+docker run -d \
+  --name mysql \
+  --restart always \
+  --network common \
+  -p 3306:3306 \
+  -v /dockerProjects/db_data:/var/lib/mysql \
+  -v /dockerProjects/mysql_logs:/logs \
+  -e MYSQL_ROOT_PASSWORD=${var.DB_ROOT_PASSWORD} \
+  -e MYSQL_DATABASE=${var.DB_NAME} \
+  -e MYSQL_USER=${var.DB_USERNAME} \
+  -e MYSQL_PASSWORD=${var.DB_PASSWORD} \
+  -e TZ=Asia/Seoul \
+  mysql:8.0 --general-log=1 --general-log-file=/var/lib/mysql/general.log
+
+# MySQL 컨테이너가 준비될 때까지 대기
+echo "MySQL이 기동될 때까지 대기 중..."
+until docker exec mysql mysql -uroot -p${var.DB_ROOT_PASSWORD} -e "SELECT 1" &> /dev/null; do
+  echo "MySQL이 아직 준비되지 않음. 5초 후 재시도..."
+  sleep 5
+done
+echo "MySQL이 준비됨. 초기화 스크립트 실행 중..."
+
+docker exec mysql mysql -uroot -p${var.DB_ROOT_PASSWORD} -e "
+CREATE USER '${var.MYSQL_USER_1}'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY '${var.PASSWORD_3}';
+CREATE USER '${var.MYSQL_USER_1}'@'172.18.%.%' IDENTIFIED WITH caching_sha2_password BY '${var.PASSWORD_2}';
+CREATE USER '${var.MYSQL_USER_2}'@'%' IDENTIFIED WITH caching_sha2_password BY '${var.PASSWORD_1}';
+
+GRANT ALL PRIVILEGES ON *.* TO '${var.MYSQL_USER_1}'@'127.0.0.1';
+GRANT ALL PRIVILEGES ON *.* TO '${var.MYSQL_USER_1}'@'172.18.%.%';
+GRANT ALL PRIVILEGES ON *.* TO '${var.MYSQL_USER_2}'@'%';
+
+CREATE DATABASE ${var.DB_NAME};
+
+FLUSH PRIVILEGES;
+"
+
+echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
+
+# app1 컨테이너 실행 (Doppler 사용)
+docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
+
+END_OF_FILE
+}
+
+#최신 AMI를 찾는 스크립트
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+# EC2 인스턴스 생성
+resource "aws_instance" "ec2_1" {
+  # 사용할 AMI ID
+  # ami 최신버전이 갱신돼 최신 ami를 받으면 기존 서버가 destroy됨
+  # 현재 서버가 destroy되는걸 막기 위해 직접 설정
+  # ami = data.aws_ami.latest_amazon_linux.id
+  ami = "ami-0eb302fcc77c2f8bd"
+  # EC2 인스턴스 유형
+  instance_type = "t3.micro"
+  # 사용할 서브넷 ID
+  subnet_id = aws_subnet.subnet_2.id
+  # 적용할 보안 그룹 ID
+  vpc_security_group_ids = [aws_security_group.sg_1.id]
+  # 퍼블릭 IP 연결 설정
+  associate_public_ip_address = true
+
+  # 인스턴스에 IAM 역할 연결
+  iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
+
+  # 인스턴스에 태그 설정
+  tags = {
+    ResourceName = "${var.prefix}-ec2-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "dev"
+  }
+
+  # 루트 볼륨 설정
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 12 # 볼륨 크기를 12GB로 설정
+  }
+
+  user_data = <<-EOF
+${local.ec2_user_data_base}
+EOF
+}

--- a/infra/dev/package.json
+++ b/infra/dev/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@kkokkio/infra-dev",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "doppler": "doppler secrets download --no-file --format env-no-quotes > .env && echo '테라폼 dev 서버용 .env 파일을 생성했습니다.'"
+  }
+}

--- a/infra/dev/variable.tf
+++ b/infra/dev/variable.tf
@@ -4,9 +4,14 @@
 # doppler run -- terraform apply
 # doppler run -- terraform destroy
 
+variable "env" {
+  description = "env"
+  default     = "dev"
+}
+
 variable "prefix" {
   description = "Prefix for all resources"
-  default     = "team04"
+  default     = "team04-dev"
 }
 
 variable "region" {

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "@kkokkio/infra",
-  "private": true,
-  "version": "1.0.0",
-  "scripts": {
-    "doppler": "doppler secrets download --no-file --format env-no-quotes > .env && echo '테라폼 용 .env 파일을 생성했습니다.'"
-  }
-}

--- a/infra/prd/main.tf
+++ b/infra/prd/main.tf
@@ -1,0 +1,434 @@
+terraform {
+  // aws 라이브러리 불러옴
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+# AWS 설정 시작
+provider "aws" {
+  region = var.region
+}
+# AWS 설정 끝
+
+# VPC 설정 시작
+
+## 변경 ## 기존 개발 환경 VPC를 데이터 소스로 가져옴 - 새로운 VPC 생성 부분을 삭제하고 추가됨
+# 기존 VPC를 CIDR 블록으로 찾습니다. (기존 dev VPC가 10.0.0.0/16임을 가정)
+data "aws_vpc" "existing_vpc" {
+  filter {
+    name = "cidr-block"
+    values = ["10.0.0.0/16"]
+  }
+  filter {
+    name = "tag:Name"
+    values = ["team04-kkokkio"]
+  }
+  filter {
+    name = "tag:Team"
+    values = ["devcos5-team04"]
+  }
+}
+
+resource "aws_subnet" "subnet_1" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.5.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_subnet" "subnet_2" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.6.0/24"
+  availability_zone       = "${var.region}b"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-2"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_subnet" "subnet_3" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.7.0/24"
+  availability_zone       = "${var.region}c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-3"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_subnet" "subnet_4" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.8.0/24"
+  availability_zone       = "${var.region}d"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-4"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+# 기존 VPC에 연결된 인터넷 게이트웨이를 데이터 소스로 가져옴
+data "aws_internet_gateway" "existing_igw" {
+  filter {
+    name = "tag:Name"
+    values = ["team04-kkokkio"]
+  }
+
+  filter {
+    name = "tag:Team"
+    values = ["devcos5-team04"]
+  }
+}
+
+resource "aws_route_table" "rt_1" {
+  vpc_id = data.aws_vpc.existing_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = data.aws_internet_gateway.existing_igw.id
+  }
+
+  tags = {
+    ResourceName = "${var.prefix}-rt-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_route_table_association" "association_1" {
+  subnet_id      = aws_subnet.subnet_1.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_2" {
+  subnet_id      = aws_subnet.subnet_2.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_3" {
+  subnet_id      = aws_subnet.subnet_3.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_4" {
+  subnet_id      = aws_subnet.subnet_4.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_security_group" "sg_1" {
+  name   = "${var.prefix}-sg-1"
+  vpc_id = data.aws_vpc.existing_vpc.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 81
+    to_port   = 81
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 6379
+    to_port   = 6379
+    protocol  = "tcp"
+    self      = true
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    ResourceName = "${var.prefix}-sg-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+# RDS 리소스
+
+# RDS Subnet Group (서브넷 2개 이상 필요) - 새로 생성된 prd 서브넷 3, 4 사용
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name = "${var.prefix}-rds-subnet-group"
+  subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
+
+  tags = {
+    Name = "${var.prefix}-rds-subnet-group"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+# RDS 보안 그룹 (EC2에서 접근 가능하도록 설정)
+resource "aws_security_group" "rds_sg" {
+  name   = "${var.prefix}-rds-sg"
+  vpc_id = data.aws_vpc.existing_vpc.id
+
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol = "tcp"
+    # cidr_blocks = ["10.0.0.0/16"] # EC2와 동일한 VPC 대역
+    security_groups = [aws_security_group.sg_1.id]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.prefix}-rds-sg"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+# RDS 인스턴스 생성 (MySQL)
+resource "aws_db_instance" "mysql" {
+  identifier            = "${var.prefix}-mysql"
+  engine                = "mysql"
+  engine_version        = "8.0"
+  instance_class        = "db.t3.micro"
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp2"
+
+  db_name  = var.DB_NAME
+  username = var.DB_USERNAME
+  password = var.DB_PASSWORD
+  port     = 3306
+
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+  multi_az             = false
+  publicly_accessible  = false
+  skip_final_snapshot  = true
+  deletion_protection  = false
+
+  tags = {
+    Name = "${var.prefix}-mysql"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+
+# EC2 설정 시작
+
+# EC2 역할 생성
+resource "aws_iam_role" "ec2_role_1" {
+  name = "${var.prefix}-ec2-role-1"
+
+  # 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
+  assume_role_policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Action": "sts:AssumeRole",
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow"
+      }
+    ]
+  }
+  EOF
+}
+
+# EC2 역할에 AmazonS3FullAccess 정책을 부착
+resource "aws_iam_role_policy_attachment" "s3_full_access" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+# EC2 역할에 AmazonEC2RoleforSSM 정책을 부착
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+# IAM 인스턴스 프로파일 생성
+resource "aws_iam_instance_profile" "instance_profile_1" {
+  name = "${var.prefix}-instance-profile-1"
+  role = aws_iam_role.ec2_role_1.name
+}
+
+locals {
+  ec2_user_data_base = <<-END_OF_FILE
+#!/bin/bash
+# 가상 메모리 4GB 설정
+sudo dd if=/dev/zero of=/swapfile bs=128M count=32
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+sudo sh -c 'echo "/swapfile swap swap defaults 0 0" >> /etc/fstab'
+
+# 도커 설치 및 실행/활성화
+yum install docker -y
+systemctl enable docker
+systemctl start docker
+
+# gnupg2 설치 (doppler CLI용)
+yum install -y --allowerasing gnupg2
+
+# 도플러 CLI 설치
+curl -Ls https://cli.doppler.com/install.sh | sudo DOPPLER_INSTALL_DIR=/usr/local/bin sh
+
+# 도커 네트워크 생성
+docker network create common
+
+# nginx-proxy-manager
+docker run -d \
+  --name npm_1 \
+  --restart unless-stopped \
+  --network common \
+  -p 80:80 \
+  -p 443:443 \
+  -p 81:81 \
+  -e TZ=Asia/Seoul \
+  -v /dockerProjects/npm_1/volumes/data:/data \
+  -v /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt \
+  jc21/nginx-proxy-manager:latest
+
+# redis 컨테이너 (도커컴포즈 맞춤)
+docker run -d \
+  --name redis \
+  --restart always \
+  --network common \
+  -p 6379:6379 \
+  -v /dockerProjects/redis_data:/data \
+  -e TZ=Asia/Seoul \
+  redis:alpine
+
+# prd 환경에선 mysql 대신 rds 사용
+"
+
+echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
+
+# app1 컨테이너 실행 (Doppler 사용)
+docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
+
+END_OF_FILE
+}
+
+#최신 AMI를 찾는 스크립트
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+# EC2 인스턴스 생성
+resource "aws_instance" "ec2_1" {
+  # 사용할 AMI ID
+  # ami 최신버전이 갱신돼 최신 ami를 받으면 기존 서버가 destroy됨
+  # 현재 서버가 destroy되는걸 막기 위해 직접 설정
+  # ami = data.aws_ami.latest_amazon_linux.id
+  ami = "ami-0eb302fcc77c2f8bd"
+  # EC2 인스턴스 유형
+  instance_type = "t3.micro"
+  # 사용할 서브넷 ID
+  subnet_id = aws_subnet.subnet_2.id
+  # 적용할 보안 그룹 ID
+  vpc_security_group_ids = [aws_security_group.sg_1.id]
+  # 퍼블릭 IP 연결 설정
+  associate_public_ip_address = true
+
+  # 인스턴스에 IAM 역할 연결
+  iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
+
+  # 인스턴스에 태그 설정
+  tags = {
+    ResourceName = "${var.prefix}-ec2-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+
+  # 루트 볼륨 설정
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 12 # 볼륨 크기를 12GB로 설정
+  }
+
+  user_data = <<-EOF
+${local.ec2_user_data_base}
+EOF
+}

--- a/infra/prd/main.tf
+++ b/infra/prd/main.tf
@@ -321,6 +321,9 @@ sudo mkswap /swapfile
 sudo swapon /swapfile
 sudo sh -c 'echo "/swapfile swap swap defaults 0 0" >> /etc/fstab'
 
+캐시 및 목록 업데이트를 먼저 수행하여 설치 안정성 확보
+sudo yum update -y
+
 # 도커 설치 및 실행/활성화
 yum install docker -y
 systemctl enable docker
@@ -359,7 +362,6 @@ docker run -d \
   redis:alpine
 
 # prd 환경에선 mysql 대신 rds 사용
-"
 
 echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
 

--- a/infra/prd/main.tf.default
+++ b/infra/prd/main.tf.default
@@ -1,3 +1,5 @@
+# vpc 한도 때문에 기존 수정되기 전 코드
+
 terraform {
   // aws 라이브러리 불러옴
   required_providers {
@@ -15,7 +17,7 @@ provider "aws" {
 
 # VPC 설정 시작
 resource "aws_vpc" "vpc_1" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "10.10.0.0/16"
 
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -24,12 +26,13 @@ resource "aws_vpc" "vpc_1" {
     ResourceName = "${var.prefix}-vpc-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
 resource "aws_subnet" "subnet_1" {
   vpc_id                  = aws_vpc.vpc_1.id
-  cidr_block              = "10.0.1.0/24"
+  cidr_block              = "10.10.1.0/24"
   availability_zone       = "${var.region}a"
   map_public_ip_on_launch = true
 
@@ -37,12 +40,13 @@ resource "aws_subnet" "subnet_1" {
     ResourceName = "${var.prefix}-subnet-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
 resource "aws_subnet" "subnet_2" {
   vpc_id                  = aws_vpc.vpc_1.id
-  cidr_block              = "10.0.2.0/24"
+  cidr_block              = "10.10.2.0/24"
   availability_zone       = "${var.region}b"
   map_public_ip_on_launch = true
 
@@ -50,12 +54,13 @@ resource "aws_subnet" "subnet_2" {
     ResourceName = "${var.prefix}-subnet-2"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
 resource "aws_subnet" "subnet_3" {
   vpc_id                  = aws_vpc.vpc_1.id
-  cidr_block              = "10.0.3.0/24"
+  cidr_block              = "10.10.3.0/24"
   availability_zone       = "${var.region}c"
   map_public_ip_on_launch = true
 
@@ -63,12 +68,13 @@ resource "aws_subnet" "subnet_3" {
     ResourceName = "${var.prefix}-subnet-3"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
 resource "aws_subnet" "subnet_4" {
   vpc_id                  = aws_vpc.vpc_1.id
-  cidr_block              = "10.0.4.0/24"
+  cidr_block              = "10.10.4.0/24"
   availability_zone       = "${var.region}d"
   map_public_ip_on_launch = true
 
@@ -76,6 +82,7 @@ resource "aws_subnet" "subnet_4" {
     ResourceName = "${var.prefix}-subnet-4"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
@@ -86,6 +93,7 @@ resource "aws_internet_gateway" "igw_1" {
     ResourceName = "${var.prefix}-igw-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
@@ -101,6 +109,7 @@ resource "aws_route_table" "rt_1" {
     ResourceName = "${var.prefix}-rt-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
 
@@ -164,17 +173,10 @@ resource "aws_security_group" "sg_1" {
   }
 
   ingress {
-    from_port = 3306
-    to_port   = 3306
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
     from_port = 6379
     to_port   = 6379
     protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    self      = true
   }
 
   egress {
@@ -188,8 +190,79 @@ resource "aws_security_group" "sg_1" {
     ResourceName = "${var.prefix}-sg-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 }
+
+# RDS 리소스
+
+# RDS Subnet Group (서브넷 2개 이상 필요)
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name = "${var.prefix}-rds-subnet-group"
+  subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
+
+  tags = {
+    Name = "${var.prefix}-rds-subnet-group"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+# RDS 보안 그룹 (EC2에서 접근 가능하도록 설정)
+resource "aws_security_group" "rds_sg" {
+  name   = "${var.prefix}-rds-sg"
+  vpc_id = aws_vpc.vpc_1.id
+
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol  = "tcp"
+    cidr_blocks = ["10.10.0.0/16"] # EC2와 동일한 VPC 대역
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.prefix}-rds-sg"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+# RDS 인스턴스 생성 (MySQL)
+resource "aws_db_instance" "mysql" {
+  identifier            = "${var.prefix}-mysql"
+  engine                = "mysql"
+  engine_version        = "8.0"
+  instance_class        = "db.t3.micro"
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp2"
+
+  db_name  = var.DB_NAME
+  username = var.DB_USERNAME
+  password = var.DB_PASSWORD
+  port     = 3306
+
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+  multi_az             = false
+  publicly_accessible  = false
+  skip_final_snapshot  = true
+  deletion_protection  = false
+
+  tags = {
+    Name = "${var.prefix}-mysql"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
 
 # EC2 설정 시작
 
@@ -280,47 +353,13 @@ docker run -d \
   -e TZ=Asia/Seoul \
   redis:alpine
 
-# mysql 컨테이너 (도커컴포즈 맞춤)
-docker run -d \
-  --name mysql \
-  --restart always \
-  --network common \
-  -p 3306:3306 \
-  -v /dockerProjects/db_data:/var/lib/mysql \
-  -v /dockerProjects/mysql_logs:/logs \
-  -e MYSQL_ROOT_PASSWORD=${var.DB_ROOT_PASSWORD} \
-  -e MYSQL_DATABASE=${var.DB_NAME} \
-  -e MYSQL_USER=${var.DB_USERNAME} \
-  -e MYSQL_PASSWORD=${var.DB_PASSWORD} \
-  -e TZ=Asia/Seoul \
-  mysql:8.0 --general-log=1 --general-log-file=/var/lib/mysql/general.log
-
-# MySQL 컨테이너가 준비될 때까지 대기
-echo "MySQL이 기동될 때까지 대기 중..."
-until docker exec mysql mysql -uroot -p${var.DB_ROOT_PASSWORD} -e "SELECT 1" &> /dev/null; do
-  echo "MySQL이 아직 준비되지 않음. 5초 후 재시도..."
-  sleep 5
-done
-echo "MySQL이 준비됨. 초기화 스크립트 실행 중..."
-
-docker exec mysql mysql -uroot -p${var.DB_ROOT_PASSWORD} -e "
-CREATE USER '${var.MYSQL_USER_1}'@'127.0.0.1' IDENTIFIED WITH caching_sha2_password BY '${var.PASSWORD_3}';
-CREATE USER '${var.MYSQL_USER_1}'@'172.18.%.%' IDENTIFIED WITH caching_sha2_password BY '${var.PASSWORD_2}';
-CREATE USER '${var.MYSQL_USER_2}'@'%' IDENTIFIED WITH caching_sha2_password BY '${var.PASSWORD_1}';
-
-GRANT ALL PRIVILEGES ON *.* TO '${var.MYSQL_USER_1}'@'127.0.0.1';
-GRANT ALL PRIVILEGES ON *.* TO '${var.MYSQL_USER_1}'@'172.18.%.%';
-GRANT ALL PRIVILEGES ON *.* TO '${var.MYSQL_USER_2}'@'%';
-
-CREATE DATABASE ${var.DB_NAME};
-
-FLUSH PRIVILEGES;
+# prd 환경에선 mysql 대신 rds 사용
 "
 
 echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
 
 # app1 컨테이너 실행 (Doppler 사용)
-docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio:latest
+docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
 
 END_OF_FILE
 }
@@ -354,7 +393,10 @@ data "aws_ami" "latest_amazon_linux" {
 # EC2 인스턴스 생성
 resource "aws_instance" "ec2_1" {
   # 사용할 AMI ID
-  ami = data.aws_ami.latest_amazon_linux.id
+  # ami 최신버전이 갱신돼 최신 ami를 받으면 기존 서버가 destroy됨
+  # 현재 서버가 destroy되는걸 막기 위해 직접 설정
+  # ami = data.aws_ami.latest_amazon_linux.id
+  ami = "ami-0eb302fcc77c2f8bd"
   # EC2 인스턴스 유형
   instance_type = "t3.micro"
   # 사용할 서브넷 ID
@@ -372,6 +414,7 @@ resource "aws_instance" "ec2_1" {
     ResourceName = "${var.prefix}-ec2-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
+    env          = "prd"
   }
 
   # 루트 볼륨 설정

--- a/infra/prd/package.json
+++ b/infra/prd/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@kkokkio/infra-prd",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "doppler": "doppler secrets download --no-file --format env-no-quotes > .env && echo '테라폼 prd 서버용 .env 파일을 생성했습니다.'"
+  }
+}

--- a/infra/prd/variable.tf
+++ b/infra/prd/variable.tf
@@ -1,0 +1,75 @@
+# 도플러 환경변수를 적용해 실행해야 합니다.
+# doppler run -- terraform init
+# doppler run -- terraform plan
+# doppler run -- terraform apply
+# doppler run -- terraform destroy
+
+variable "env" {
+  description = "env"
+  default     = "prd"
+}
+
+variable "prefix" {
+  description = "Prefix for all resources"
+  default     = "team04-prd"
+}
+
+variable "region" {
+  description = "region"
+  default     = "ap-northeast-2"
+}
+
+variable "db_name" {
+  description = "db name"
+  default     = "kkokkio_prd"
+}
+
+variable "PASSWORD_1" {
+  description = "password_1 (Provided via Doppler)"
+}
+
+variable "PASSWORD_2" {
+  description = "password_2 (Provided via Doppler)"
+}
+
+variable "PASSWORD_3" {
+  description = "password_3 (Provided via Doppler)"
+}
+
+variable "GITHUB_ACCESS_TOKEN_1" {
+  description = "github_access_token_1, read:packages only (Provided via Doppler)"
+}
+
+variable "GITHUB_ACCESS_TOKEN_1_OWNER" {
+  description = "github_access_token_1_owner (Provided via Doppler)"
+}
+
+
+variable "MYSQL_USER_1" {
+  description = "mysql_user_1 (Provided via Doppler)"
+}
+
+variable "MYSQL_USER_2" {
+  description = "mysql_user_2 (Provided via Doppler)"
+}
+
+variable "DB_ROOT_PASSWORD" {
+  description = "DB_ROOT_PASSWORD (Provided via Doppler)"
+}
+
+variable "DB_NAME" {
+  description = "DB_NAME (Provided via Doppler)"
+}
+
+variable "DB_USERNAME" {
+  description = "DB_USERNAME (Provided via Doppler)"
+}
+
+variable "DB_PASSWORD" {
+  description = "DB_PASSWORD (Provided via Doppler)"
+}
+
+variable "DOPPLER_SERVICE_TOKEN" {
+  description = "DOPPLER_SERVICE_TOKEN of backend production (Provided via Doppler)"
+}
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "workspaces": [
     "backend",
-    "infra"
+    "infra/dev",
+    "infra/prd"
   ],
   "scripts": {
     "doppler": "npm run doppler:setup && turbo run doppler",


### PR DESCRIPTION
…포 프로세스 추가

## 연관된 이슈

> [#134](https://github.com/prgrms-web-devcourse-final-project/WEB4_5_GAEPPADAK_BE/issues/134)

## 작업 내용

> 
-프로덕션 서버와 개발 서버 분리
-프로덕션 서버에 RDS 연결 및 테라폼으로 환경 생성
-깃허브 액션에 개발과 프로덕션별 배포 프로세스 추가
-도플러의 backend prd 환경의 DB_HOST를 변경

## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
> 추후 깃허브 액션 prd 코드의 트리거 브랜치를 main으로 변경
