### PR TITLE
build: 프로덕션 배포 트리거를 main 브랜치로 변경

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -1,4 +1,4 @@
-name: deploy-develop
+name: deploy-prd
 
 on:
   push:

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -9,8 +9,7 @@ on:
       - 'backend/settings.gradle'
       - 'backend/Dockerfile'
     branches:
-      #     TODO:첫 병합 후 develop에서 main으로 변경할 것
-      - develop
+      - main
 jobs:
   makeTagAndRelease:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 연관된 이슈

> [#136](https://github.com/prgrms-web-devcourse-final-project/WEB4_5_GAEPPADAK_BE/issues/136)

## 작업 내용

> 프로덕션 서버 배포 트리거 브랜치를 main으로 변경

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 

closes #136