### PR TITLE
Feat/154 add id in rest api response

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/comment/dto/CommentDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/dto/CommentDto.java
@@ -9,7 +9,7 @@ import site.kkokkio.domain.comment.entity.Comment;
 
 @Builder
 public record CommentDto(
-	@NonNull Long id,
+	@NonNull Long commentId,
 	@NonNull UUID memberId,
 	@NonNull String nickname,
 	@NonNull String body,
@@ -18,7 +18,7 @@ public record CommentDto(
 ) {
 	public static CommentDto from(Comment comment) {
 		return CommentDto.builder()
-			.id(comment.getId())
+			.commentId(comment.getId())
 			.memberId(comment.getMember().getId())
 			.nickname(comment.getMember().getNickname())
 			.body(comment.getBody())

--- a/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
@@ -72,7 +72,7 @@ public class MemberService {
 	//
 	// 	// JWT 토큰 발생 시 포함할 사용자 정보 설정
 	// 	Map<String, Object> claims = new HashMap<>();
-	// 	claims.put("id", member.getId());
+	// 	claims.put("commentId", member.getId());
 	// 	claims.put("email", member.getEmail());
 	// 	claims.put("nickname", member.getNickname());
 	// 	claims.put("role", member.getRole());

--- a/backend/src/main/java/site/kkokkio/domain/post/controller/dto/PostSearchSourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/controller/dto/PostSearchSourceListResponse.java
@@ -37,7 +37,7 @@ public record PostSearchSourceListResponse(
 
 	@Builder
 	private record SearchSourceList(
-		@NonNull String id,
+		@NonNull String sourceId,
 		@NonNull String url,
 		String thumbnailUrl,
 		@NonNull String title,
@@ -45,7 +45,7 @@ public record PostSearchSourceListResponse(
 		) {
 		public static SearchSourceList from(SourceDto sourceDto) {
 			return SearchSourceList.builder()
-				.id(sourceDto.id())
+				.sourceId(sourceDto.sourceId())
 				.url(sourceDto.url())
 				.thumbnailUrl(sourceDto.thumbnailUrl())
 				.title(sourceDto.title())

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/dto/SourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/dto/SourceListResponse.java
@@ -14,7 +14,7 @@ public record SourceListResponse(
 
 	@Builder
 	private record SourceList(
-		@NonNull String id,
+		@NonNull String sourceId,
 		@NonNull String url,
 		@NonNull String thumbnailUrl,
 		@NonNull String title
@@ -24,6 +24,7 @@ public record SourceListResponse(
 		return SourceListResponse.builder()
 			.list(sources.stream()
 				.map(source -> SourceList.builder()
+					.sourceId(source.sourceId())
 					.url(source.url())
 					.thumbnailUrl(source.thumbnailUrl())
 					.title(source.title())

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/dto/SourceListResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/dto/SourceListResponse.java
@@ -14,6 +14,7 @@ public record SourceListResponse(
 
 	@Builder
 	private record SourceList(
+		@NonNull String id,
 		@NonNull String url,
 		@NonNull String thumbnailUrl,
 		@NonNull String title

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/NewsDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/NewsDto.java
@@ -26,7 +26,7 @@ public record NewsDto(
                      .normalizedUrl(normalized)
                      .title(sanitizedTitle)
                      .description(sanitizedDescription)
-                     .thumbnailUrl(null)
+                     .thumbnailUrl(null) // Naver News API에서 제공하지 않음
                      .publishedAt(pubDate)
                      .platform(platform)
                      .build();

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/SourceDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/SourceDto.java
@@ -10,7 +10,7 @@ import site.kkokkio.global.enums.Platform;
 
 @Builder
 public record SourceDto(
-	@NonNull String id,
+	@NonNull String sourceId,
 	@NonNull String url,
 	String thumbnailUrl,
 	@NonNull String title,
@@ -19,7 +19,7 @@ public record SourceDto(
 	) {
 	public static SourceDto from(Source source) {
 		return SourceDto.builder()
-			.id(source.getFingerprint())
+			.sourceId(source.getFingerprint())
 			.url(source.getNormalizedUrl())
 			.thumbnailUrl(source.getThumbnailUrl())
 			.title(source.getTitle())

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/TopSourceItemDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/TopSourceItemDto.java
@@ -1,16 +1,17 @@
 package site.kkokkio.domain.source.dto;
 
+import java.time.LocalDateTime;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.NonNull;
 import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
 
-import java.time.LocalDateTime;
-
 @Builder
 @Schema(description = "실시간 인기 출처 목록의 개별 항목 DTO")
 public record TopSourceItemDto(
+        @NonNull String sourceId,
         @NonNull String url,
         @NonNull String title,
         String description,
@@ -21,6 +22,7 @@ public record TopSourceItemDto(
 ) {
     public static TopSourceItemDto fromSource(Source source) {
         return TopSourceItemDto.builder()
+                .sourceId(source.getFingerprint())
                 .url(source.getNormalizedUrl())
                 .title(source.getTitle())
                 .description(source.getDescription())

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/VideoDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/VideoDto.java
@@ -1,11 +1,11 @@
 package site.kkokkio.domain.source.dto;
 
+import java.time.LocalDateTime;
+
 import lombok.Builder;
 import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.util.HashUtils;
-
-import java.time.LocalDateTime;
 
 /**
  * YouTube Data API 응답에서 변환되어 파이프라인 내에서 사용되는 비디오 정보 DTO
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
  */
 @Builder
 public record VideoDto(
-        String id,
+        String url,
         String title,
         String description,
         String thumbnailUrl,
@@ -27,19 +27,15 @@ public record VideoDto(
      * @return Source Entity
      */
     public Source toEntity(Platform platform) {
-
-        // 유튜브 비디오 ID를 사용해 정규화된 URL 생성
-        String normalizedUrl = "https://www.youtube.com/watch?v=" + this.id;
-
         // URL로 fingerprint 생성
-        String fingerprint = HashUtils.sha256Hex(normalizedUrl);
+        String fingerprint = HashUtils.sha256Hex(url);
 
         // 유튜브 썸네일은 여러 사이즈가 제공되는데, DTO에 담은 thumbnailUrl을 그대로 사용
         // 만약 API 응답에서 여러 URL을 받는다면, Adapter에서 변환 시 원하는
         // 사이즈의 URL을 선택하여 thumbnailUrl에 담아야 함
         return Source.builder()
                 .fingerprint(fingerprint)
-                .normalizedUrl(normalizedUrl)
+                .normalizedUrl(url)
                 .title(this.title)
                 .description(this.description)
                 .thumbnailUrl(this.thumbnailUrl)

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
@@ -1,17 +1,18 @@
 package site.kkokkio.domain.source.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
 import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.entity.PostSource;
 import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
-
-import java.util.List;
 
 @Repository
 public interface PostSourceRepository extends JpaRepository<PostSource, Long>, PostSourceRepositoryCustom {
@@ -70,6 +71,7 @@ public interface PostSourceRepository extends JpaRepository<PostSource, Long>, P
 	 */
 	@Query("""
             SELECT new site.kkokkio.domain.source.dto.TopSourceItemDto(
+            	s.fingerprint,
                 s.normalizedUrl,
                 s.title,
                 s.description,

--- a/backend/src/main/java/site/kkokkio/infra/youtube/video/YoutubeVideoApiAdapter.java
+++ b/backend/src/main/java/site/kkokkio/infra/youtube/video/YoutubeVideoApiAdapter.java
@@ -1,27 +1,5 @@
 package site.kkokkio.infra.youtube.video;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
-import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
-import io.github.resilience4j.retry.annotation.Retry;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.ClientResponse;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriBuilder;
-import reactor.core.publisher.Mono;
-import site.kkokkio.domain.source.dto.VideoDto;
-import site.kkokkio.domain.source.port.out.VideoApiPort;
-import site.kkokkio.global.exception.ServiceException;
-import site.kkokkio.infra.common.exception.ExternalApiErrorUtil;
-import site.kkokkio.infra.common.exception.RetryableExternalApiException;
-import site.kkokkio.infra.youtube.video.dto.*;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +8,37 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import site.kkokkio.domain.source.dto.VideoDto;
+import site.kkokkio.domain.source.port.out.VideoApiPort;
+import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.infra.common.exception.ExternalApiErrorUtil;
+import site.kkokkio.infra.common.exception.RetryableExternalApiException;
+import site.kkokkio.infra.youtube.video.dto.ResourceId;
+import site.kkokkio.infra.youtube.video.dto.SearchSnippet;
+import site.kkokkio.infra.youtube.video.dto.ThumbnailDetails;
+import site.kkokkio.infra.youtube.video.dto.YoutubeError;
+import site.kkokkio.infra.youtube.video.dto.YoutubeErrorDetail;
+import site.kkokkio.infra.youtube.video.dto.YoutubeErrorResponse;
+import site.kkokkio.infra.youtube.video.dto.YoutubeSearchItem;
+import site.kkokkio.infra.youtube.video.dto.YoutubeVideosSearchResponse;
 
 @Slf4j
 @Component
@@ -193,9 +202,11 @@ public class YoutubeVideoApiAdapter implements VideoApiPort {
             }
         }
 
+        String youtubeUrl = "https://www.youtube.com/watch?v=" + id.getVideoId();
+
         try {
             return Optional.of(VideoDto.builder()
-                    .id(id.getVideoId())
+                    .url(youtubeUrl)
                     .title(snippet.getTitle())
                     .description(snippet.getDescription())
                     .thumbnailUrl(thumbnailUrl)

--- a/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
@@ -72,6 +72,7 @@ class CommentControllerV1Test {
 				.accept(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.data.list[0].commentId").value(1))
 			.andExpect(jsonPath("$.data.list[0].body").value("댓글"));
 	}
 
@@ -94,6 +95,7 @@ class CommentControllerV1Test {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.data.commentId").value(1))
 			.andExpect(jsonPath("$.data.body").value("새 댓글"));
 	}
 
@@ -133,6 +135,7 @@ class CommentControllerV1Test {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.data.commentId").value(1))
 			.andExpect(jsonPath("$.data.body").value("수정된 댓글"));
 	}
 
@@ -182,6 +185,7 @@ class CommentControllerV1Test {
 				.with(csrf()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.data.commentId").value(1))
 			.andExpect(jsonPath("$.data.likeCount").value(1));
 	}
 
@@ -201,6 +205,7 @@ class CommentControllerV1Test {
 				.with(csrf()))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.data.commentId").value(1))
 			.andExpect(jsonPath("$.data.likeCount").value(0));
 	}
 }

--- a/backend/src/test/java/site/kkokkio/domain/post/controller/PostControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/post/controller/PostControllerV1Test.java
@@ -255,7 +255,7 @@ public class PostControllerV1Test {
 		// given
 		List<SourceDto> mockSources = IntStream.range(0, 5)
 			.mapToObj(
-				i -> new SourceDto("id-" + i, "url-" + i, "thumb-" + i, "title-" + i, LocalDateTime.now(), Platform.NAVER_NEWS))
+				i -> new SourceDto("commentId-" + i, "url-" + i, "thumb-" + i, "title-" + i, LocalDateTime.now(), Platform.NAVER_NEWS))
 			.toList();
 		when(keywordService.getPostListByKeyword(eq(keywordText), any(PageRequest.class)))
 			.thenReturn(new PageImpl<>(postDtos));
@@ -273,7 +273,7 @@ public class PostControllerV1Test {
 			.andExpect(MockMvcResultMatchers.jsonPath("$.message").value("성공적으로 조회되었습니다."))
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list").isArray())
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list.length()").value(5))
-			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list[0].sourceId").value("id-1"))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list[0].sourceId").value("commentId-0"))
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.meta.page").value(0))
 			.andDo(print());
 	}

--- a/backend/src/test/java/site/kkokkio/domain/post/controller/PostControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/post/controller/PostControllerV1Test.java
@@ -273,6 +273,7 @@ public class PostControllerV1Test {
 			.andExpect(MockMvcResultMatchers.jsonPath("$.message").value("성공적으로 조회되었습니다."))
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list").isArray())
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list.length()").value(5))
+			.andExpect(MockMvcResultMatchers.jsonPath("$.data.list[0].sourceId").value("id-1"))
 			.andExpect(MockMvcResultMatchers.jsonPath("$.data.meta.page").value(0))
 			.andDo(print());
 	}

--- a/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
@@ -156,7 +156,7 @@ class SourceControllerV1Test {
         // Mocking 할 서비스 메소드의 반환 값 생성
         List<TopSourceItemDto> mockItemList = List.of(
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-1")
+                        .sourceId("source-commentId-1")
                         .url("https://youtube.com/watch?v=video1")
                         .title("유튜브 인기 영상 제목 1")
                         .description(null)
@@ -165,7 +165,7 @@ class SourceControllerV1Test {
                         .platform(Platform.YOUTUBE)
                         .build(),
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-2")
+                        .sourceId("source-commentId-2")
                         .url("https://youtube.com/watch?v=video2")
                         .title("유튜브 인기 영상 제목 2")
                         .description(null)
@@ -174,7 +174,7 @@ class SourceControllerV1Test {
                         .platform(Platform.YOUTUBE)
                         .build(),
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-3")
+                        .sourceId("source-commentId-3")
                         .url("https://youtube.com/watch?v=video3")
                         .title("유튜브 인기 영상 제목 3")
                         .description(null)
@@ -183,7 +183,7 @@ class SourceControllerV1Test {
                         .platform(Platform.YOUTUBE)
                         .build(),
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-4")
+                        .sourceId("source-commentId-4")
                         .url("https://youtube.com/watch?v=video4")
                         .title("유튜브 인기 영상 제목 4")
                         .description(null)
@@ -219,7 +219,7 @@ class SourceControllerV1Test {
                 .andExpect(jsonPath("$.data.meta").exists())
 
                 // 첫번째 값 검증
-                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-id-1"))
+                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-commentId-1"))
                 .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
                 .andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
                 .andExpect(jsonPath("$.data.list[0].description").value(nullValue()))
@@ -283,7 +283,7 @@ class SourceControllerV1Test {
         // Mocking 할 서비스 메소드의 반환 값 생성
         List<TopSourceItemDto> mockItemList = List.of(
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-1")
+                        .sourceId("source-commentId-1")
                         .url("https://news.naver.com/article/1")
                         .title("네이버 인기 뉴스 제목 1")
                         .description("네이버 요약 뉴스 내용 1")
@@ -292,7 +292,7 @@ class SourceControllerV1Test {
                         .platform(Platform.NAVER_NEWS)
                         .build(),
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-2")
+                        .sourceId("source-commentId-2")
                         .url("https://news.naver.com/article/2")
                         .title("네이버 인기 뉴스 제목 2")
                         .description("네이버 요약 뉴스 내용 2")
@@ -301,7 +301,7 @@ class SourceControllerV1Test {
                         .platform(Platform.NAVER_NEWS)
                         .build(),
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-3")
+                        .sourceId("source-commentId-3")
                         .url("https://news.naver.com/article/3")
                         .title("네이버 인기 뉴스 제목 3")
                         .description("네이버 요약 뉴스 내용 3")
@@ -310,7 +310,7 @@ class SourceControllerV1Test {
                         .platform(Platform.NAVER_NEWS)
                         .build(),
                 TopSourceItemDto.builder()
-                        .sourceId("source-id-4")
+                        .sourceId("source-commentId-4")
                         .url("https://news.naver.com/article/4")
                         .title("네이버 인기 뉴스 제목 4")
                         .description("네이버 요약 뉴스 내용 4")
@@ -346,7 +346,7 @@ class SourceControllerV1Test {
                 .andExpect(jsonPath("$.data.meta").exists())
 
                 // 첫번째 값 검증
-                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-id-1"))
+                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-commentId-1"))
                 .andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
                 .andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
                 .andExpect(jsonPath("$.data.list[0].description").value("네이버 요약 뉴스 내용 1"))

--- a/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
@@ -1,14 +1,29 @@
 package site.kkokkio.domain.source.controller;
 
+import static org.hamcrest.Matchers.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
 import site.kkokkio.domain.source.dto.TopSourceItemDto;
@@ -17,16 +32,6 @@ import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.global.security.CustomUserDetailsService;
 import site.kkokkio.global.util.JwtUtils;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = SourceControllerV1.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -70,6 +75,7 @@ class SourceControllerV1Test {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-1"))
                 .andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
                 .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
                 .andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
@@ -136,6 +142,7 @@ class SourceControllerV1Test {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-1"))
                 .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
                 .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
                 .andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
@@ -149,6 +156,7 @@ class SourceControllerV1Test {
         // Mocking 할 서비스 메소드의 반환 값 생성
         List<TopSourceItemDto> mockItemList = List.of(
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-1")
                         .url("https://youtube.com/watch?v=video1")
                         .title("유튜브 인기 영상 제목 1")
                         .description(null)
@@ -157,6 +165,7 @@ class SourceControllerV1Test {
                         .platform(Platform.YOUTUBE)
                         .build(),
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-2")
                         .url("https://youtube.com/watch?v=video2")
                         .title("유튜브 인기 영상 제목 2")
                         .description(null)
@@ -165,6 +174,7 @@ class SourceControllerV1Test {
                         .platform(Platform.YOUTUBE)
                         .build(),
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-3")
                         .url("https://youtube.com/watch?v=video3")
                         .title("유튜브 인기 영상 제목 3")
                         .description(null)
@@ -173,6 +183,7 @@ class SourceControllerV1Test {
                         .platform(Platform.YOUTUBE)
                         .build(),
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-4")
                         .url("https://youtube.com/watch?v=video4")
                         .title("유튜브 인기 영상 제목 4")
                         .description(null)
@@ -208,6 +219,7 @@ class SourceControllerV1Test {
                 .andExpect(jsonPath("$.data.meta").exists())
 
                 // 첫번째 값 검증
+                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-id-1"))
                 .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
                 .andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
                 .andExpect(jsonPath("$.data.list[0].description").value(nullValue()))
@@ -271,6 +283,7 @@ class SourceControllerV1Test {
         // Mocking 할 서비스 메소드의 반환 값 생성
         List<TopSourceItemDto> mockItemList = List.of(
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-1")
                         .url("https://news.naver.com/article/1")
                         .title("네이버 인기 뉴스 제목 1")
                         .description("네이버 요약 뉴스 내용 1")
@@ -279,6 +292,7 @@ class SourceControllerV1Test {
                         .platform(Platform.NAVER_NEWS)
                         .build(),
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-2")
                         .url("https://news.naver.com/article/2")
                         .title("네이버 인기 뉴스 제목 2")
                         .description("네이버 요약 뉴스 내용 2")
@@ -287,6 +301,7 @@ class SourceControllerV1Test {
                         .platform(Platform.NAVER_NEWS)
                         .build(),
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-3")
                         .url("https://news.naver.com/article/3")
                         .title("네이버 인기 뉴스 제목 3")
                         .description("네이버 요약 뉴스 내용 3")
@@ -295,6 +310,7 @@ class SourceControllerV1Test {
                         .platform(Platform.NAVER_NEWS)
                         .build(),
                 TopSourceItemDto.builder()
+                        .sourceId("source-id-4")
                         .url("https://news.naver.com/article/4")
                         .title("네이버 인기 뉴스 제목 4")
                         .description("네이버 요약 뉴스 내용 4")
@@ -330,6 +346,7 @@ class SourceControllerV1Test {
                 .andExpect(jsonPath("$.data.meta").exists())
 
                 // 첫번째 값 검증
+                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-id-1"))
                 .andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
                 .andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
                 .andExpect(jsonPath("$.data.list[0].description").value("네이버 요약 뉴스 내용 1"))

--- a/backend/src/test/java/site/kkokkio/domain/source/service/SourceServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/service/SourceServiceTest.java
@@ -1,5 +1,18 @@
 package site.kkokkio.domain.source.service;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -7,7 +20,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
 import reactor.core.publisher.Mono;
 import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyDto;
 import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
@@ -29,17 +47,6 @@ import site.kkokkio.domain.source.repository.SourceRepository;
 import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.infra.common.exception.RetryableExternalApiException;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.BDDMockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class SourceServiceTest {
@@ -337,25 +344,25 @@ class SourceServiceTest {
 
         // Mocking할 Repository의 반환 값 (Page<TopSourceItemDto>) 생성
         List<TopSourceItemDto> mockSourceItemDtoList = Arrays.asList(
-                TopSourceItemDto.builder().url("http://youtube.com/v1").title("영상제목1").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-1").url("http://youtube.com/v1").title("영상제목1").description(null)
                         .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(90).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v2").title("영상제목2").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-2").url("http://youtube.com/v2").title("영상제목2").description(null)
                         .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(70).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v3").title("영상제목3").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-3").url("http://youtube.com/v3").title("영상제목3").description(null)
                         .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(30).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v4").title("영상제목4").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-4").url("http://youtube.com/v4").title("영상제목4").description(null)
                         .thumbnailUrl("thumb4").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(77).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v5").title("영상제목5").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-5").url("http://youtube.com/v5").title("영상제목5").description(null)
                         .thumbnailUrl("thumb5").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(70).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v6").title("영상제목6").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-6").url("http://youtube.com/v6").title("영상제목6").description(null)
                         .thumbnailUrl("thumb6").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(86).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v7").title("영상제목7").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-7").url("http://youtube.com/v7").title("영상제목7").description(null)
                         .thumbnailUrl("thumb7").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(43).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v8").title("영상제목8").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-8").url("http://youtube.com/v8").title("영상제목8").description(null)
                         .thumbnailUrl("thumb8").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(86).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v9").title("영상제목9").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-9").url("http://youtube.com/v9").title("영상제목9").description(null)
                         .thumbnailUrl("thumb9").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(42).build(),
-                TopSourceItemDto.builder().url("http://youtube.com/v10").title("영상제목10").description(null)
+                TopSourceItemDto.builder().sourceId("source-id-10").url("http://youtube.com/v10").title("영상제목10").description(null)
                         .thumbnailUrl("thumb10").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(55).build()
         );
 
@@ -561,25 +568,25 @@ class SourceServiceTest {
 
         // Mocking할 Repository의 반환 값 (Page<TopSourceItemDto>) 생성
         List<TopSourceItemDto> mockSourceItemDtoList = Arrays.asList(
-                TopSourceItemDto.builder().url("http://news.naver.com/article/1").title("뉴스제목1").description("네이버 뉴스 요약 1")
+                TopSourceItemDto.builder().sourceId("source-id-1").url("http://news.naver.com/article/1").title("뉴스제목1").description("네이버 뉴스 요약 1")
                         .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(90).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/2").title("뉴스제목2").description("네이버 뉴스 요약 2")
+                TopSourceItemDto.builder().sourceId("source-id-2").url("http://news.naver.com/article/2").title("뉴스제목2").description("네이버 뉴스 요약 2")
                         .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(70).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/3").title("뉴스제목3").description("네이버 뉴스 요약 3")
+                TopSourceItemDto.builder().sourceId("source-id-3").url("http://news.naver.com/article/3").title("뉴스제목3").description("네이버 뉴스 요약 3")
                         .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(30).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/4").title("뉴스제목4").description("네이버 뉴스 요약 4")
+                TopSourceItemDto.builder().sourceId("source-id-4").url("http://news.naver.com/article/4").title("뉴스제목4").description("네이버 뉴스 요약 4")
                         .thumbnailUrl("thumb4").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(77).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/5").title("뉴스제목5").description("네이버 뉴스 요약 5")
+                TopSourceItemDto.builder().sourceId("source-id-5").url("http://news.naver.com/article/5").title("뉴스제목5").description("네이버 뉴스 요약 5")
                         .thumbnailUrl("thumb5").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(70).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/6").title("뉴스제목6").description("네이버 뉴스 요약 6")
+                TopSourceItemDto.builder().sourceId("source-id-6").url("http://news.naver.com/article/6").title("뉴스제목6").description("네이버 뉴스 요약 6")
                         .thumbnailUrl("thumb6").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(86).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/7").title("뉴스제목7").description("네이버 뉴스 요약 7")
+                TopSourceItemDto.builder().sourceId("source-id-7").url("http://news.naver.com/article/7").title("뉴스제목7").description("네이버 뉴스 요약 7")
                         .thumbnailUrl("thumb7").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(43).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/8").title("뉴스제목8").description("네이버 뉴스 요약 8")
+                TopSourceItemDto.builder().sourceId("source-id-8").url("http://news.naver.com/article/8").title("뉴스제목8").description("네이버 뉴스 요약 8")
                         .thumbnailUrl("thumb8").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(86).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/9").title("뉴스제목9").description("네이버 뉴스 요약 9")
+                TopSourceItemDto.builder().sourceId("source-id-9").url("http://news.naver.com/article/9").title("뉴스제목9").description("네이버 뉴스 요약 9")
                         .thumbnailUrl("thumb9").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(42).build(),
-                TopSourceItemDto.builder().url("http://news.naver.com/article/10").title("뉴스제목10").description("네이버 뉴스 요약 10")
+                TopSourceItemDto.builder().sourceId("source-id-10").url("http://news.naver.com/article/10").title("뉴스제목10").description("네이버 뉴스 요약 10")
                         .thumbnailUrl("thumb10").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(55).build()
         );
 
@@ -780,10 +787,10 @@ class SourceServiceTest {
         // videoApi.fetchVideos()가 각 키워드에 대해 VideoDto 목록을 담은 Mono를 반환하도록 설정
         // 키워드1에 대한 응답
         List<VideoDto> video1 = Arrays.asList(
-                VideoDto.builder().id("v1_id_k1").title("영상1 제목 k1").publishedAt(
+                VideoDto.builder().url("https://www.youtube.com/watch?v=v1_id_k1").title("영상1 제목 k1").publishedAt(
                                 LocalDateTime.now().minusDays(1)).thumbnailUrl("thumb1_k1")
                         .description("desc1_k1").build(),
-                VideoDto.builder().id("v2_id_k1").title("영상2 제목 k1").publishedAt(
+                VideoDto.builder().url("https://www.youtube.com/watch?v=v2_id_k1").title("영상2 제목 k1").publishedAt(
                                 LocalDateTime.now().minusDays(2)).thumbnailUrl("thumb2_k1")
                         .description("desc2_k1").build()
         );
@@ -793,11 +800,11 @@ class SourceServiceTest {
 
         // 키워드2에 대한 응답 (일부러 중복되는 영상 포함)
         List<VideoDto> video2 = Arrays.asList(
-                VideoDto.builder().id("v3_id_k2").title("영상3 제목 k2").publishedAt(
+                VideoDto.builder().url("https://www.youtube.com/watch?v=v3_id_k2").title("영상3 제목 k2").publishedAt(
                                 LocalDateTime.now().minusDays(3)).thumbnailUrl("thumb3_k2")
                         .description("desc3_k2").build(),
                 // 중복 영상
-                VideoDto.builder().id("v2_id_k1").title("영상2 제목 k1").publishedAt(
+                VideoDto.builder().url("https://www.youtube.com/watch?v=v2_id_k1").title("영상2 제목 k1").publishedAt(
                                 LocalDateTime.now().minusDays(2)).thumbnailUrl("thumb2_k1")
                         .description("desc2_k1").build()
         );
@@ -934,7 +941,7 @@ class SourceServiceTest {
 
         // 키워드2에 대해 정상 응답 설정
         List<VideoDto> video2 = Arrays.asList(
-                VideoDto.builder().id("v_id_k2").title("정상 영상 제목 k2")
+                VideoDto.builder().url("https://www.youtube.com/watch?v=v_id_k2").title("정상 영상 제목 k2")
                         .publishedAt(LocalDateTime.now().minusDays(1))
                         .thumbnailUrl("thumb_k2").description("desc_k2").build()
         );

--- a/backend/src/test/java/site/kkokkio/infra/youtube/video/YoutubeVideoApiAdapterMockTest.java
+++ b/backend/src/test/java/site/kkokkio/infra/youtube/video/YoutubeVideoApiAdapterMockTest.java
@@ -1,14 +1,15 @@
 package site.kkokkio.infra.youtube.video;
 
+import static org.assertj.core.api.Assertions.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
 import reactor.test.StepVerifier;
 import site.kkokkio.domain.source.dto.VideoDto;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
@@ -33,7 +34,7 @@ public class YoutubeVideoApiAdapterMockTest {
                     VideoDto firstVideo = list.getFirst();
 
                     // mockVideoId1에 해당하는 데이터로 검증
-                    assertThat(firstVideo.id()).isEqualTo("mockVideoId1");
+                    assertThat(firstVideo.url()).isEqualTo("https://www.youtube.com/watch?v=mockVideoId1");
                     assertThat(firstVideo.title()).isEqualTo("Mock 영상 제목 1: 인기있는 컨텐츠");
                     assertThat(firstVideo.description()).isEqualTo(
                             "이 영상은 테스트 목적으로 생성된 가짜 영상입니다. 실제 데이터가 아닙니다.");

--- a/backend/src/test/java/site/kkokkio/infra/youtube/video/YoutubeVideoApiAdapterTest.java
+++ b/backend/src/test/java/site/kkokkio/infra/youtube/video/YoutubeVideoApiAdapterTest.java
@@ -1,11 +1,13 @@
 package site.kkokkio.infra.youtube.video;
 
-import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
-import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
-import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
-import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import io.github.resilience4j.retry.RetryRegistry;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collections;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,18 +30,17 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFunction;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import io.github.resilience4j.retry.RetryRegistry;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import site.kkokkio.domain.source.dto.VideoDto;
 import site.kkokkio.infra.common.exception.RetryableExternalApiException;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.Collections;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -130,7 +131,7 @@ public class YoutubeVideoApiAdapterTest {
             assertThat(list).hasSize(1);
 
             VideoDto video = list.getFirst();
-            assertThat(video.id()).isEqualTo("testVideoId1");
+            assertThat(video.url()).isEqualTo("https://www.youtube.com/watch?v=testVideoId1");
             assertThat(video.title()).isEqualTo("testTitle");
             assertThat(video.description()).isEqualTo("testDescription 1");
             assertThat(video.thumbnailUrl()).isEqualTo("http://test.com/thumb1.jpg");


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #154 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> REST API Response에서 식별자(id)가 없는 경우 모두 추가 및 명명컨벤션 통일

- GET /posts/{postId}/videos -> `sourceId`
- GET /posts/{postId}/news -> `sourceId`
- GET /news/top -> `sourceId`
- GET /videos/top -> `sourceId`
- GET /posts/search/sources -> `sourceId`
- GET posts/{postId}/comments -> `commentId`
- POST /posts/{postId}/comments -> `commentId`
- PATCH /comments/{commentId} -> `commentId`
- POST /comments/{commentId}/like -> `commentId`
- DELETE /comments/{commentId}/like -> `commentId`

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #154