### PR TITLE
Fix/152 refresh token info

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
 import site.kkokkio.domain.member.controller.dto.MemberLoginRequest;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
-import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -61,9 +60,9 @@ public class AuthControllerV1 {
 	@PostMapping("/refresh")
 	@ApiErrorCodeExamples({ErrorCode.REFRESH_TOKEN_NOT_FOUND,
 		ErrorCode.REFRESH_TOKEN_MISMATCH, ErrorCode.REFRESH_TOKEN_INTERNAL_ERROR})
-	public RsData<TokenDto> refreshToken(HttpServletRequest request, HttpServletResponse response) {
-		TokenDto tokenDto = authService.refreshToken(request, response);
-		return new RsData<>("200", "토큰이 재발급되었습니다.", tokenDto);
+	public RsData<Void> refreshToken(HttpServletRequest request, HttpServletResponse response) {
+		authService.refreshToken(request, response);
+		return new RsData<>("200", "토큰이 재발급되었습니다.");
 	}
 
 	@Operation(summary = "로그아웃")

--- a/backend/src/main/java/site/kkokkio/domain/member/dto/TokenDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/dto/TokenDto.java
@@ -1,4 +1,0 @@
-package site.kkokkio.domain.member.dto;
-
-public record TokenDto(String accessToken, String refreshToken) {
-}

--- a/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
@@ -96,7 +96,7 @@ public class MemberService {
 
 		//페이로드에서 사용자 이메일 추출
 		Claims claims = jwtUtils.getPayload(token);
-		String email = claims.get("email", String.class);
+		String email = claims.getSubject();
 
 		// 멤버 조회 및 응답 DTO 변환
 		Member memberInfo = findByEmail(email);

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -153,7 +153,7 @@ public class JwtUtils {
 	public void setRefreshTokenInCookie(String token, HttpServletResponse response) {
 		ResponseCookie cookie = ResponseCookie.from("refreshToken", token)
 			.httpOnly(true)     // 자바스크립트 접근 차단 (XSS 방지)
-			.path("/auth")      // 인증 경로에서만 접근 가능
+			.path("/api/v1/auth")      // 인증 경로에서만 접근 가능
 
 			// Todo: 프론트, 백엔드 도메인 일치 후(Strict)적용
 			.sameSite("None")   // 외부 사이트 요청 허용 (CORS 환경 대응)

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/AuthControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/AuthControllerV1Test.java
@@ -21,7 +21,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
-import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -121,18 +120,13 @@ public class AuthControllerV1Test {
 	@DisplayName("토큰 재발급 - 성공")
 	void refreshTokenSuccess() throws Exception {
 		// given
-		TokenDto tokenDto = new TokenDto("newAccessToken", "existingRefreshToken");
-
-		given(authService.refreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
-			.willReturn(tokenDto);
+		willCallRealMethod().given(jwtUtils).setJwtInCookie(anyString(), any(HttpServletResponse.class));
 
 		// when & then
 		mockMvc.perform(post("/api/v1/auth/refresh"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("200"))
-			.andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."))
-			.andExpect(jsonPath("$.data.accessToken").value("newAccessToken"))
-			.andExpect(jsonPath("$.data.refreshToken").value("existingRefreshToken"));
+			.andExpect(jsonPath("$.message").value("토큰이 재발급되었습니다."));
 	}
 
 	@Test

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -25,7 +25,6 @@ import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
-import site.kkokkio.domain.member.dto.TokenDto;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.enums.MemberRole;
 import site.kkokkio.global.exception.ServiceException;
@@ -133,17 +132,19 @@ class AuthServiceV1Test {
 		String rt = "refresh-token";
 
 		Claims claims = mock(Claims.class);
-		given(claims.get("email", String.class)).willReturn(email);
+		given(claims.getSubject()).willReturn(email);
 
 		given(jwtUtils.getRefreshTokenFromCookies(request)).willReturn(Optional.of(rt));
 		given(jwtUtils.getPayload(rt)).willReturn(claims);
 		given(valueOperations.get("refreshToken:" + email)).willReturn(rt);
 		given(jwtUtils.createToken(email, claims)).willReturn("new-access");
+		willDoNothing().given(jwtUtils).setJwtInCookie(eq("new-access"), eq(response));
 
-		TokenDto result = authService.refreshToken(request, response);
+		// when
+		authService.refreshToken(request, response);
 
-		assertThat(result.accessToken()).isEqualTo("new-access");
-		assertThat(result.refreshToken()).isEqualTo(rt);
+		// then
+		then(jwtUtils).should().setJwtInCookie("new-access", response);
 	}
 
 	@Test

--- a/backend/src/test/java/site/kkokkio/domain/member/service/MemberServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/MemberServiceV1Test.java
@@ -128,7 +128,7 @@ class MemberServiceV1Test {
 		// 페이로드에서 email 추출
 		Claims claims = mock(Claims.class);
 		given(jwtUtils.getPayload("valid.token")).willReturn(claims);
-		given(claims.get("email", String.class)).willReturn("user@example.com");
+		given(claims.getSubject()).willReturn("user@example.com");
 
 		// MemberServiceV1 내부 findByEmail 호출
 		Member member = Member.builder()


### PR DESCRIPTION
## 연관된 이슈

> ex) #152 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 회원정보 조회 오류 해결 -> email 주소가 subject에 담겨 있었는데 엉뚱한 곳에서 email 추출 하는 오류 해결
- refeshToken을 찾지 못하는 오류 -> 리프레시 토큰을 쿠키에 저장할 때 잘못된 인증경로 접근하고 있는 문제 확인, 경로 설정을 다시하여 문제 해결
- 토큰 재발급시 TokenDto로 Token값을 반환하고 있었는데 보안 문제가 발생할 것 같아. token 데이터는 쿠키에서만 관리하는거로 수정

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
closes #152