### PR TITLE
Feat/68 email verified 2

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -82,6 +82,10 @@ services:
       - "6379:6379"
     volumes: # 마운트할 볼륨 설정
       - ./redis_data:/data
+    command: [
+      "redis-server",
+      "--notify-keyspace-events", "Ex"
+    ]
 
 networks:
   monitoring:

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
@@ -4,7 +4,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -75,7 +74,7 @@ public class AuthControllerV1 {
 
 	@Operation(summary = "이메일 인증 코드 전송")
 	@PostMapping("/verify-email")
-	public RsData<Void> requestAuthCode(@RequestParam String email) throws MessagingException {
+	public RsData<Void> requestAuthCode(String email) throws MessagingException {
 
 		boolean isSend = mailService.sendAuthCode(email);
 		return isSend

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -38,6 +38,7 @@ public class MemberControllerV1 {
 	@PostMapping("/signup")
 	public RsData<MemberResponse> createMember(@RequestBody @Validated MemberSignUpRequest request) {
 		MemberResponse memberResponse = memberService.createMember(request);
+		memberService.siginUpUnverified(memberResponse);
 		return new RsData<>("200", "회원가입이 완료되었습니다.", memberResponse);
 	}
 

--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -35,6 +35,10 @@ public class AuthService {
 		if (!passwordEncoder.matches(rawPassword, member.getPasswordHash())) {
 			throw new ServiceException("401", "비밀번호가 올바르지 않습니다.");
 		}
+		// 인증 확인
+		if (!member.isEmailVerified()) {
+			throw new ServiceException("403", "인증되지 않은 회원입니다.");
+		}
 
 		Map<String, Object> claims = new HashMap<>();
 		claims.put("isEmailVerified", member.isEmailVerified());

--- a/backend/src/main/java/site/kkokkio/domain/member/service/MailService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/MailService.java
@@ -103,17 +103,22 @@ public class MailService {
 		String authCode = sendSimpleMessage(email); // 이메일 인증 코드 발송
 
 		if (authCode != null) {
-			// Redis에 인증 코드 저장 (만료 시간 설정)
-			ValueOperations<String, String> values = redisTemplate.opsForValue();
-			// 키 이름에 접두어 추가해서 저장
-			String key = EMAIL_AUTH_PREFIX + email;
-
-			// Redis에 저장하고 만료 시간 설정 (밀리초를 초 단위로 변환)
-			values.set(key, authCode, Duration.ofSeconds(300)); // 5분
-
+			storeAuthCodeInRedis(email, authCode);
 			return true;
 		}
 		return false;
+	}
+
+	// 인증 코드 Redis 저장
+	@Transactional
+	public void storeAuthCodeInRedis(String email, String authCode) {
+		// Redis에 인증 코드 저장 (만료 시간 설정)
+		ValueOperations<String, String> values = redisTemplate.opsForValue();
+		// 키 이름에 접두어 추가해서 저장
+		String key = EMAIL_AUTH_PREFIX + email;
+
+		// Redis에 저장하고 만료 시간 설정 (밀리초를 초 단위로 변환)
+		values.set(key, authCode, Duration.ofSeconds(300)); // 5분
 	}
 
 	// 인증 코드 검증

--- a/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/MemberService.java
@@ -1,5 +1,8 @@
 package site.kkokkio.domain.member.service;
 
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +26,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtils jwtUtils;
+	private final RedisTemplate<String, String> redisTemplate;
 
 	// 회원 가입
 	@Transactional
@@ -49,6 +53,14 @@ public class MemberService {
 			.build();
 		memberRepository.save(member);
 		return new MemberResponse(member);
+	}
+
+	// // Redis에 가입 할 회원 ID 저장
+	public void siginUpUnverified(MemberResponse response) {
+		// Redis에 가입 할 회원 ID 저장
+		String redisKey = "SIGNUP_UNVERIFIED:" + response.getEmail();
+		redisTemplate.opsForValue()
+			.set(redisKey, "1", Duration.ofMinutes(5)); // 5분
 	}
 
 	// 이메일로 회원 조회

--- a/backend/src/main/java/site/kkokkio/global/config/RedisListenerConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/RedisListenerConfig.java
@@ -1,0 +1,30 @@
+package site.kkokkio.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+import site.kkokkio.global.listener.RedisExpiredKeyListener;
+
+@Configuration
+@Profile("!test")
+public class RedisListenerConfig {
+
+	// 만료된 Redis 키 이벤트에 반응하는 RedisMessageListenerContainer 빈
+	@Bean
+	public RedisMessageListenerContainer keyExpirationListenerContainer(
+		RedisConnectionFactory cf,
+		RedisExpiredKeyListener expiredListener) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		// RedisConnectionFactory 설정
+		container.setConnectionFactory(cf);
+		// expired 이벤트 패턴 구독
+		container.addMessageListener(
+			expiredListener,
+			new PatternTopic("__keyevent@*__:expired"));
+		return container;
+	}
+}

--- a/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
@@ -42,6 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		if (List.of(
 			"/api/v1/auth/login",
 			"/api/v1/auth/signup",
+			"/api/v1/auth/verify-email",
+			"/api/v1/auth/check-email",
 			"/api/v1/auth/refresh"
 		).contains(path)) {
 			return true;
@@ -52,8 +54,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			("POST".equals(method) && path.matches("^/api/v1/posts/\\d+/comments$"))            // 댓글 작성
 				|| ("PATCH".equals(method) && path.matches("^/api/v1/comments/\\d+$"))          // 댓글 수정
 				|| ("DELETE".equals(method) && path.matches("^/api/v1/comments/\\d+$"))         // 댓글 삭제
-				|| ("POST".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"))	  // 댓글 좋아요
-				|| ("DELETE".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"));	  // 댓글 좋아요 취소
+				|| ("POST".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"))      // 댓글 좋아요
+				|| ("DELETE".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"));      // 댓글 좋아요 취소
 
 		// isCommentWriteEndpoint 이면 필터 동작(= false 리턴), 아니면 스킵(= true 리턴)
 		return !isCommentWriteEndpoint;

--- a/backend/src/main/java/site/kkokkio/global/listener/RedisExpiredKeyListener.java
+++ b/backend/src/main/java/site/kkokkio/global/listener/RedisExpiredKeyListener.java
@@ -1,0 +1,34 @@
+package site.kkokkio.global.listener;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.member.repository.MemberRepository;
+
+@Component
+@RequiredArgsConstructor
+public class RedisExpiredKeyListener implements MessageListener {
+	private final MemberRepository memberRepository;
+
+	// 만료된 Redis 키가 넘어올 때마다 호출되는 콜백 메서드
+	@Override
+	public void onMessage(Message msg, byte[] pattern) {
+		String key = msg.toString();
+
+		// "SIGNUP_UNVERIFIED:"로 시작되는 키만 확인
+		if (!key.startsWith("SIGNUP_UNVERIFIED:"))
+			return;
+
+		// key에서 email값 분리
+		String email = key.split(":", 2)[1];
+
+		// 메일 인증이 안된 회원 삭제
+		memberRepository.findByEmail(email).ifPresent(m -> {
+			if (!m.isEmailVerified()) {
+				memberRepository.delete(m);
+			}
+		});
+	}
+}

--- a/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/service/AuthServiceV1Test.java
@@ -88,6 +88,8 @@ class AuthServiceV1Test {
 			"role", MemberRole.USER
 		);
 
+		member.setEmailVerified(true); // 테스트 통과를 위해 임시 이메일 인증
+
 		// given
 		given(memberService.findByEmail(email)).willReturn(member);
 		given(passwordEncoder.matches(rawPw, encPw)).willReturn(true);


### PR DESCRIPTION
## 연관된 이슈

> ex) #68 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- 이메일 인증/인가 보완
- Redis keyspace notifications 기능 활성화
- 이메일 전송 PathVarible로 롤백
- Redis에 인증할 email을 key로 받아 5분내로 메일 인증하지 않을 경우 회원가입 취소
- 로그인 시 인증된 이메일 여부 확인 로직 추가

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- 회원 가입 로직 설명
- 회원가입->이메일 인증->인증번호 발송->인증번호 검증->회원 활성화
(단, 5분내로 이메일 인증 실패 할 경우 회원가입 취소)<-이 5분간 해당 이메일로 회원가입 불가

closes #68