### PR TITLE
Bug/161 comment qa fix

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
@@ -54,7 +54,8 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 작성")
-	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_3})
+	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
+		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH, ErrorCode.POST_NOT_FOUND_3})
 	@PostMapping("/posts/{postId}/comments")
 	public RsData<CommentDto> createComment(
 		@PathVariable("postId") Long postId,
@@ -69,7 +70,9 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 수정")
-	@ApiErrorCodeExamples({ErrorCode.COMMENT_UPDATE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
+	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
+		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+		ErrorCode.COMMENT_UPDATE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@PatchMapping("/comments/{commentId}")
 	public RsData<CommentDto> updateComment(
 		@PathVariable("commentId") Long commentId,
@@ -85,7 +88,9 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 삭제")
-	@ApiErrorCodeExamples({ErrorCode.COMMENT_DELETE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
+	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
+		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+		ErrorCode.COMMENT_DELETE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@DeleteMapping("/comments/{commentId}")
 	public RsData<Empty> deleteComment(
 		@PathVariable("commentId") Long commentId,
@@ -99,7 +104,9 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 좋아요")
-	@ApiErrorCodeExamples({ErrorCode.COMMENT_LIKE_BAD_REQUEST, ErrorCode.COMMENT_LIKE_FORBIDDEN,
+	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
+		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+		ErrorCode.COMMENT_LIKE_BAD_REQUEST, ErrorCode.COMMENT_LIKE_FORBIDDEN,
 		ErrorCode.COMMENT_NOT_FOUND})
 	@PostMapping("/comments/{commentId}/like")
 	public RsData<CommentDto> likeComment(
@@ -115,7 +122,9 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 좋아요 취소")
-	@ApiErrorCodeExamples({ErrorCode.COMMENT_LIKE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
+	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
+		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+		ErrorCode.COMMENT_LIKE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@DeleteMapping("/comments/{commentId}/like")
 	public RsData<CommentDto> unlikeComment(
 		@PathVariable("commentId") Long commentId,

--- a/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
@@ -93,7 +93,7 @@ public class CommentControllerV1 {
 	) {
 		commentService.deleteCommentById(commentId, userDetails.getMember().getId());
 		return new RsData<>(
-			"204",
+			"200",
 			"댓글이 삭제되었습니다."
 		);
 	}

--- a/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
@@ -54,8 +54,8 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 작성")
-	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
-		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH, ErrorCode.POST_NOT_FOUND_3})
+	@ApiErrorCodeExamples({ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
+		ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH, ErrorCode.POST_NOT_FOUND_3})
 	@PostMapping("/posts/{postId}/comments")
 	public RsData<CommentDto> createComment(
 		@PathVariable("postId") Long postId,
@@ -70,8 +70,8 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 수정")
-	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
-		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+	@ApiErrorCodeExamples({ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
+		ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH,
 		ErrorCode.COMMENT_UPDATE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@PatchMapping("/comments/{commentId}")
 	public RsData<CommentDto> updateComment(
@@ -88,8 +88,8 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 삭제")
-	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
-		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+	@ApiErrorCodeExamples({ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
+		ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH,
 		ErrorCode.COMMENT_DELETE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@DeleteMapping("/comments/{commentId}")
 	public RsData<Empty> deleteComment(
@@ -104,8 +104,8 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 좋아요")
-	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
-		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
+	@ApiErrorCodeExamples({ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
+		ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH,
 		ErrorCode.COMMENT_LIKE_BAD_REQUEST, ErrorCode.COMMENT_LIKE_FORBIDDEN,
 		ErrorCode.COMMENT_NOT_FOUND})
 	@PostMapping("/comments/{commentId}/like")
@@ -122,9 +122,9 @@ public class CommentControllerV1 {
 	}
 
 	@Operation(summary = "댓글 좋아요 취소")
-	@ApiErrorCodeExamples({ErrorCode.AUTH_TOKEN_EXPIRED, ErrorCode.AUTH_UNSUPPORTED_TOKEN,
-		ErrorCode.AUTH_MALFORMED_TOKEN, ErrorCode.AUTH_CREDENTIALS_MISMATCH,
-		ErrorCode.COMMENT_LIKE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
+	@ApiErrorCodeExamples({ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
+		ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH,
+		ErrorCode.COMMENT_UNLIKE_BAD_REQUEST, ErrorCode.COMMENT_LIKE_FORBIDDEN, ErrorCode.COMMENT_NOT_FOUND})
 	@DeleteMapping("/comments/{commentId}/like")
 	public RsData<CommentDto> unlikeComment(
 		@PathVariable("commentId") Long commentId,

--- a/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
@@ -110,6 +110,9 @@ public class CommentService {
 		if (comment.getMember().getId().equals(member.getId())) {
 			throw new ServiceException("403", "본인 댓글은 좋아요 할 수 없습니다.");
 		}
+		if (!commentLikeRepository.existsByComment(comment)) {
+			throw new ServiceException("400", "이미 좋아요가 취소된 상태입니다.");
+		}
 
 		if (commentLikeRepository.existsByComment(comment)) {
 			commentLikeRepository.deleteByComment(comment);

--- a/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
@@ -110,14 +110,13 @@ public class CommentService {
 		if (comment.getMember().getId().equals(member.getId())) {
 			throw new ServiceException("403", "본인 댓글은 좋아요 할 수 없습니다.");
 		}
-		if (!commentLikeRepository.existsByComment(comment)) {
-			throw new ServiceException("400", "이미 좋아요가 취소된 상태입니다.");
-		}
 
 		if (commentLikeRepository.existsByComment(comment)) {
 			commentLikeRepository.deleteByComment(comment);
 			comment.decreaseLikeCount();
 			commentRepository.save(comment);
+		} else {
+			throw new ServiceException("400", "이미 좋아요가 취소된 상태입니다.");
 		}
 		return CommentDto.from(comment);
 	}

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -84,10 +84,11 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize ->
 				authorize
 					// — USER 로그인 필요
-					.requestMatchers(HttpMethod.POST, "/api/v1/posts/*/comments").authenticated()
-					.requestMatchers(HttpMethod.PATCH, "/api/v1/comments/*").authenticated()
-					.requestMatchers(HttpMethod.DELETE, "/api/v1/comments/*").authenticated()
-					.requestMatchers(HttpMethod.POST, "/api/v1/comments/*/like").authenticated()
+					.requestMatchers(HttpMethod.POST, "/api/v1/posts/*/comments").authenticated()		// 댓글 작성
+					.requestMatchers(HttpMethod.PATCH, "/api/v1/comments/*").authenticated()			// 댓글 수정
+					.requestMatchers(HttpMethod.DELETE, "/api/v1/comments/*").authenticated()			// 댓글 삭제
+					.requestMatchers(HttpMethod.POST, "/api/v1/comments/*/like").authenticated()		// 댓글 좋아요
+					.requestMatchers(HttpMethod.DELETE, "/api/v1/comments/*/like").authenticated()	// 댓글 좋아요 취소
 
 					// 그 외 모든 요청 허용
 					.anyRequest().permitAll()
@@ -102,14 +103,14 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 모든 출처 허용 (운영 환경 배포 시 수정 필요)
 		configuration.setAllowedOriginPatterns(Arrays.asList(
-			"https://login.aleph.kr",// Todo: 임시 프론트 배포 URL1
+			"https://login.aleph.kr", // Todo: 임시 프론트 배포 URL1
 			"https://www.app4.qwas.shop", // Todo: 임시 프론트 배포 URL2
 			"https://web.api.deploy.kkokkio.site:3000", // 프론트 API URL
 			"http://localhost:3000", // 로컬용
 			"https://api.deploy.kkokkio.site", // 백엔드 dev API URL
 			"https://api.prd.kkokkio.site"// 백엔드 prod API URL
 		)); // 프론트 사이트 추가
-		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용 HTTP 메소드
+		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS")); // 허용 HTTP 메소드
 		// configuration.setAllowedHeaders(Arrays.asList("*")); // HTTP 헤더(모두 허용)
 		configuration.setAllowCredentials(true); // 쿠키 등 자격 증명
 		// 클라이언트 노출 헤더

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -27,7 +27,11 @@ public enum ErrorCode {
 	KEYWORD_METRIC_HOURLY_NOT_FOUND("404", "KeywordMetricHourly를 찾을 수 없습니다."),
 	KEYWORDS_NOT_FOUND_1("404", "키워드를 불러오지 못했습니다."),
 	KEYWORDS_NOT_FOUND_2("404", "Keyword를 찾을 수 없습니다."),
-	NAVER_BAD_GATEWAY("502", "Empty response from Naver News API");
+	NAVER_BAD_GATEWAY("502", "Empty response from Naver News API"),
+	AUTH_TOKEN_EXPIRED("401", "만료된 토큰"),
+	AUTH_UNSUPPORTED_TOKEN("401", "지원하지 않는 토큰 형식"),
+	AUTH_MALFORMED_TOKEN("401", "토큰 구조 오류"),
+	AUTH_CREDENTIALS_MISMATCH("401", "토큰 정보 불일치");
 
 	private final String code;
 	private final String message;

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -28,10 +28,10 @@ public enum ErrorCode {
 	KEYWORDS_NOT_FOUND_1("404", "키워드를 불러오지 못했습니다."),
 	KEYWORDS_NOT_FOUND_2("404", "Keyword를 찾을 수 없습니다."),
 	NAVER_BAD_GATEWAY("502", "Empty response from Naver News API"),
-	AUTH_TOKEN_EXPIRED("401", "만료된 토큰"),
-	AUTH_UNSUPPORTED_TOKEN("401", "지원하지 않는 토큰 형식"),
-	AUTH_MALFORMED_TOKEN("401", "토큰 구조 오류"),
-	AUTH_CREDENTIALS_MISMATCH("401", "토큰 정보 불일치");
+	TOKEN_EXPIRED("401", "토큰이 만료되어 인증할 수 없음"),
+	UNSUPPORTED_TOKEN("400", "지원하지 않는 토큰 형식"),
+	MALFORMED_TOKEN("400", "클라이언트가 보낸 토큰 자체가 형식적으로 잘못됨"),
+	CREDENTIALS_MISMATCH("401", "토큰 서명 불일치 등으로 인증 실패");
 
 	private final String code;
 	private final String message;

--- a/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
+++ b/backend/src/main/java/site/kkokkio/global/exception/doc/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 	COMMENT_DELETE_FORBIDDEN("403", "본인 댓글만 삭제할 수 있습니다."),
 	COMMENT_LIKE_FORBIDDEN("403", "본인 댓글은 좋아요 할 수 없습니다."),
 	COMMENT_LIKE_BAD_REQUEST("400", "이미 좋아요를 누른 댓글입니다."),
+	COMMENT_UNLIKE_BAD_REQUEST("400", "이미 좋아요가 취소된 상태입니다."),
 	EMAIL_ALREADY_EXIST("409", "이미 사용중인 이메일입니다."),
 	EMAIL_NOT_FOUND("404", "존재하지 않는 이메일입니다."),
 	EMAIL_UNAUTHORIZED("401", "메일이 인증되지 않은 회원입니다."),

--- a/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
@@ -165,7 +165,7 @@ class CommentControllerV1Test {
 				.with(csrf())
 				.accept(APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("204"))
+			.andExpect(jsonPath("$.code").value("200"))
 			.andExpect(jsonPath("$.message").value("댓글이 삭제되었습니다."));
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "1.0.0",
       "workspaces": [
         "backend",
-        "infra"
+        "infra/dev",
+        "infra/prd"
       ],
       "devDependencies": {
-        "turbo": "1.13.4"
+        "turbo": "2.5.3"
       }
     },
     "backend": {
@@ -23,111 +24,123 @@
       "name": "@kkokkio/infra",
       "version": "1.0.0"
     },
+    "infra/dev": {
+      "name": "@kkokkio/infra-dev",
+      "version": "1.0.0"
+    },
+    "infra/prd": {
+      "name": "@kkokkio/infra-prd",
+      "version": "1.0.0"
+    },
     "node_modules/@kkokkio/backend": {
       "resolved": "backend",
       "link": true
     },
-    "node_modules/@kkokkio/infra": {
-      "resolved": "infra",
+    "node_modules/@kkokkio/infra-dev": {
+      "resolved": "infra/dev",
+      "link": true
+    },
+    "node_modules/@kkokkio/infra-prd": {
+      "resolved": "infra/prd",
       "link": true
     },
     "node_modules/turbo": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-1.13.4.tgz",
-      "integrity": "sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.3.tgz",
+      "integrity": "sha512-iHuaNcq5GZZnr3XDZNuu2LSyCzAOPwDuo5Qt+q64DfsTP1i3T2bKfxJhni2ZQxsvAoxRbuUK5QetJki4qc5aYA==",
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "1.13.4",
-        "turbo-darwin-arm64": "1.13.4",
-        "turbo-linux-64": "1.13.4",
-        "turbo-linux-arm64": "1.13.4",
-        "turbo-windows-64": "1.13.4",
-        "turbo-windows-arm64": "1.13.4"
+        "turbo-darwin-64": "2.5.3",
+        "turbo-darwin-arm64": "2.5.3",
+        "turbo-linux-64": "2.5.3",
+        "turbo-linux-arm64": "2.5.3",
+        "turbo-windows-64": "2.5.3",
+        "turbo-windows-arm64": "2.5.3"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.13.4.tgz",
-      "integrity": "sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.3.tgz",
+      "integrity": "sha512-YSItEVBUIvAGPUDpAB9etEmSqZI3T6BHrkBkeSErvICXn3dfqXUfeLx35LfptLDEbrzFUdwYFNmt8QXOwe9yaw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.13.4.tgz",
-      "integrity": "sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.3.tgz",
+      "integrity": "sha512-5PefrwHd42UiZX7YA9m1LPW6x9YJBDErXmsegCkVp+GjmWrADfEOxpFrGQNonH3ZMj77WZB2PVE5Aw3gA+IOhg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.13.4.tgz",
-      "integrity": "sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.3.tgz",
+      "integrity": "sha512-M9xigFgawn5ofTmRzvjjLj3Lqc05O8VHKuOlWNUlnHPUltFquyEeSkpQNkE/vpPdOR14AzxqHbhhxtfS4qvb1w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.13.4.tgz",
-      "integrity": "sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.3.tgz",
+      "integrity": "sha512-auJRbYZ8SGJVqvzTikpg1bsRAsiI9Tk0/SDkA5Xgg0GdiHDH/BOzv1ZjDE2mjmlrO/obr19Dw+39OlMhwLffrw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.13.4.tgz",
-      "integrity": "sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.3.tgz",
+      "integrity": "sha512-arLQYohuHtIEKkmQSCU9vtrKUg+/1TTstWB9VYRSsz+khvg81eX6LYHtXJfH/dK7Ho6ck+JaEh5G+QrE1jEmCQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.13.4.tgz",
-      "integrity": "sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.3.tgz",
+      "integrity": "sha512-3JPn66HAynJ0gtr6H+hjY4VHpu1RPKcEwGATvGUTmLmYSYBQieVlnGDRMMoYN066YfyPqnNGCfhYbXfH92Cm0g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "docker:reset": "cd backend && docker-compose down -v && docker-compose up -d"
   },
   "devDependencies": {
-    "turbo": "1.13.4"
+    "turbo": "2.5.3"
   }
 }


### PR DESCRIPTION
## 연관된 이슈

> #161 

## 작업 내용

댓글 수정 실패 (403 CORS 발생) 수정 → cors 설정에 `PATCH` method 추가
댓글 삭제 시 ResponseBody가 반환 되지 않는 문제 해결 → 성공시 HttpStatus를 `204`에서 `200`으로 변경
댓글 좋아요 중복 취소 예외 처리 → `COMMENT_UNLIKE_BAD_REQUEST` 추가
비회원 댓글 좋아요 500 에러 핸들링 → `SecurityConfig`의 `filterChain`에 인증이 필요한 경로로 추가
댓글 관련 API 인증 관련 SpringDocs Error Example 추가

## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

저는 204 NoContent가 정말 Content를 보내지 않아서 NoContent인 줄 몰랐어요..
RsData 응답으로 통일하기 위해 삭제 api 200으로 수정했습니다!

closes #161