### PR TITLE
Bug/160 fix video top api

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import site.kkokkio.domain.keyword.controller.dto.KeywordMetricHourlyResponse;
 import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyDto;
 import site.kkokkio.domain.keyword.service.KeywordMetricHourlyService;
 import site.kkokkio.global.dto.RsData;
@@ -27,13 +28,13 @@ public class KeywordMetricHourlyControllerV1 {
 	@GetMapping("/top")
 	@ApiErrorCodeExamples({ErrorCode.KEYWORDS_NOT_FOUND_1})
 	@Operation(summary = "실시간 키워드 리스트", description = "실시간 키워드 Top 10개 보기")
-	public RsData<List<KeywordMetricHourlyDto>> getHourlyMetrics() {
+	public RsData<List<KeywordMetricHourlyResponse>> getHourlyMetrics() {
 		try {
 			List<KeywordMetricHourlyDto> responses = keywordMetricHourlyService.findHourlyMetrics();
 			return new RsData<>(
 				"200",
 				"실시간 키워드를 불러왔습니다.",
-				responses
+				responses.stream().map(KeywordMetricHourlyResponse::from).toList()
 			);
 		} catch (ServiceException e) {
 			return new RsData<>(

--- a/backend/src/main/java/site/kkokkio/domain/keyword/controller/dto/KeywordMetricHourlyResponse.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/controller/dto/KeywordMetricHourlyResponse.java
@@ -1,0 +1,27 @@
+package site.kkokkio.domain.keyword.controller.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.NonNull;
+import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyDto;
+import site.kkokkio.global.enums.Platform;
+
+@Builder
+public record KeywordMetricHourlyResponse(
+	@NonNull Long keywordId,
+	@NonNull String text,
+	@NonNull Platform platform,
+	@NonNull LocalDateTime bucketAt,
+	int score
+	) {
+
+	public static KeywordMetricHourlyResponse from(KeywordMetricHourlyDto dto) {
+		return KeywordMetricHourlyResponse.builder()
+			.keywordId(dto.keywordId())
+			.text(dto.text())
+			.platform(dto.platform())
+			.bucketAt(dto.bucketAt())
+			.score(dto.score()).build();
+	}
+}

--- a/backend/src/main/java/site/kkokkio/domain/keyword/dto/KeywordMetricHourlyDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/dto/KeywordMetricHourlyDto.java
@@ -12,6 +12,7 @@ public record KeywordMetricHourlyDto(
 	@NonNull LocalDateTime bucketAt,
 	int volume,
 	int score,
-	boolean lowVariation
+	boolean lowVariation,
+	Long postId
 	) {
 }

--- a/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyService.java
@@ -35,6 +35,7 @@ public class KeywordMetricHourlyService {
 		}
 		List<KeywordMetricHourlyDto> responses = new ArrayList<>();
 		for (KeywordMetricHourly metric : metrics) {
+			Long postId = (metric.getPost() != null) ? metric.getPost().getId() : null;
 			responses.add(new KeywordMetricHourlyDto(
 				metric.getId().getKeywordId(),
 				metric.getKeyword().getText(),
@@ -42,7 +43,8 @@ public class KeywordMetricHourlyService {
 				metric.getId().getBucketAt(),
 				metric.getVolume(),
 				metric.getScore(),
-				metric.isLowVariation()
+				metric.isLowVariation(),
+				postId
 			));
 		}
 		return responses;

--- a/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/controller/SourceControllerV1.java
@@ -1,9 +1,9 @@
 package site.kkokkio.domain.source.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -11,90 +11,94 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.source.controller.dto.SourceListResponse;
 import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
+import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
 import site.kkokkio.global.dto.RsData;
+import site.kkokkio.global.enums.Platform;
 import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
 import site.kkokkio.global.exception.doc.ErrorCode;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "Source API V1", description = "출처 관련 API 엔드포인트 V1")
 public class SourceControllerV1 {
-    private final SourceService sourceService;
+	private final SourceService sourceService;
 
-    @Operation(summary = "포스트의 출처 뉴스 Top 10 조회")
+	@Operation(summary = "포스트의 출처 뉴스 Top 10 조회")
 	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_1})
-    @GetMapping("/posts/{postId}/news")
-    public RsData<SourceListResponse> getNewsSourceList(@PathVariable("postId") Long postId) {
-        List<SourceDto> sources = sourceService.getTop10NewsSourcesByPostId(postId);
-        SourceListResponse sourceListResponse = SourceListResponse.from(sources);
-        return new RsData<>(
-                "200",
-                "성공적으로 조회되었습니다.",
-                sourceListResponse
-        );
-    }
+	@GetMapping("/posts/{postId}/news")
+	public RsData<SourceListResponse> getNewsSourceList(@PathVariable("postId") Long postId) {
+		List<SourceDto> sources = sourceService.getTop10NewsSourcesByPostId(postId);
+		SourceListResponse sourceListResponse = SourceListResponse.from(sources);
+		return new RsData<>(
+			"200",
+			"성공적으로 조회되었습니다.",
+			sourceListResponse
+		);
+	}
 
-    @Operation(summary = "포스트의 출처 영상 Top 10 조회")
+	@Operation(summary = "포스트의 출처 영상 Top 10 조회")
 	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_1})
-    @GetMapping("/posts/{postId}/videos")
-    public RsData<SourceListResponse> getVideoSourceList(@PathVariable("postId") Long postId) {
-        List<SourceDto> sources = sourceService.getTop10VideoSourcesByPostId(postId);
-        SourceListResponse sourceListResponse = SourceListResponse.from(sources);
-        return new RsData<>(
-                "200",
-                "성공적으로 조회되었습니다.",
-                sourceListResponse
-        );
-    }
+	@GetMapping("/posts/{postId}/videos")
+	public RsData<SourceListResponse> getVideoSourceList(@PathVariable("postId") Long postId) {
+		List<SourceDto> sources = sourceService.getTop10VideoSourcesByPostId(postId);
+		SourceListResponse sourceListResponse = SourceListResponse.from(sources);
+		return new RsData<>(
+			"200",
+			"성공적으로 조회되었습니다.",
+			sourceListResponse
+		);
+	}
 
-    @Operation(
-            summary = "실시간 인기 유튜브 비디오 목록 조회 (페이지네이션)",
-            description = "키워드를 통해 YouTube Data API를 호출하여 현재 한국에서 인기 있는 YouTube 비디오 목록을 가져옵니다."
-    )
+	@Operation(
+		summary = "실시간 인기 유튜브 비디오 목록 조회 (페이지네이션)",
+		description = "키워드를 통해 YouTube Data API를 호출하여 현재 한국에서 인기 있는 YouTube 비디오 목록을 가져옵니다."
+	)
 	@ApiErrorCodeExamples({ErrorCode.SOURCE_NOT_FOUND_1})
-    @GetMapping("/videos/top")
-    public RsData<TopSourceListResponse> getTopYoutubeSources(
-            @ParameterObject @PageableDefault(
-                    size = 5,
-                    sort = "score",
-                    direction = Sort.Direction.DESC
-            ) Pageable pageable
-    ) {
-        TopSourceListResponse topYoutubeSources = sourceService.getTopYoutubeSources(pageable);
+	@GetMapping("/videos/top")
+	public RsData<TopSourceListResponse> getTopYoutubeSources(
+		@ParameterObject @PageableDefault(
+			size = 5,
+			sort = "score",
+			direction = Sort.Direction.DESC
+		) Pageable pageable
+	) {
+		Page<TopSourceItemDto> topYoutubeSources = sourceService.getTopSourcesByPlatform(pageable, Platform.YOUTUBE);
 
-        return new RsData<>(
-                "200",
-                "정상적으로 호출되었습니다.",
-                topYoutubeSources
-        );
-    }
+		return new RsData<>(
+			"200",
+			"정상적으로 호출되었습니다.",
+			TopSourceListResponse.from(topYoutubeSources)
+		);
+	}
 
-    @Operation(
-            summary = "실시간 인기 네이버 뉴스 목록 조회 (페이지네이션)",
-            description = "키워드를 통해 네이버 뉴스 API를 호출하여 현재 한국에서 인기 있는 네이버 뉴스 목록을 가져옵니다."
-    )
+	@Operation(
+		summary = "실시간 인기 네이버 뉴스 목록 조회 (페이지네이션)",
+		description = "키워드를 통해 네이버 뉴스 API를 호출하여 현재 한국에서 인기 있는 네이버 뉴스 목록을 가져옵니다."
+	)
 	@ApiErrorCodeExamples({ErrorCode.SOURCE_NOT_FOUND_2})
-    @GetMapping("/news/top")
-    public RsData<TopSourceListResponse> getTopNaverNewsSources(
-            @ParameterObject @PageableDefault(
-                    size = 5,
-                    sort = "score",
-                    direction = Sort.Direction.DESC
-            ) Pageable pageable
-    ) {
-        TopSourceListResponse topNewsSources = sourceService.getTopNaverNewsSources(pageable);
+	@GetMapping("/news/top")
+	public RsData<TopSourceListResponse> getTopNaverNewsSources(
+		@ParameterObject @PageableDefault(
+			size = 5,
+			sort = "score",
+			direction = Sort.Direction.DESC
+		) Pageable pageable
+	) {
+		Page<TopSourceItemDto> topNewsSources = sourceService.getTopSourcesByPlatform(pageable, Platform.NAVER_NEWS);
 
-        return new RsData<>(
-                "200",
-                "정상적으로 호출되었습니다.",
-                topNewsSources
-        );
-    }
+		return new RsData<>(
+			"200",
+			"정상적으로 호출되었습니다.",
+			TopSourceListResponse.from(topNewsSources)
+		);
+	}
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/dto/TopSourceItemDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/dto/TopSourceItemDto.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.NonNull;
-import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
 
 @Builder
@@ -19,17 +18,4 @@ public record TopSourceItemDto(
         @NonNull LocalDateTime publishedAt,
         @NonNull Platform platform,
         int score
-) {
-    public static TopSourceItemDto fromSource(Source source) {
-        return TopSourceItemDto.builder()
-                .sourceId(source.getFingerprint())
-                .url(source.getNormalizedUrl())
-                .title(source.getTitle())
-                .description(source.getDescription())
-                .thumbnailUrl(source.getThumbnailUrl())
-                .publishedAt(source.getPublishedAt())
-                .platform(source.getPlatform())
-                .score(0)
-                .build();
-    }
-}
+) {}

--- a/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/repository/PostSourceRepository.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Repository;
 
 import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.entity.PostSource;
-import site.kkokkio.domain.source.entity.Source;
 import site.kkokkio.global.enums.Platform;
 
 @Repository
@@ -31,68 +30,48 @@ public interface PostSourceRepository extends JpaRepository<PostSource, Long>, P
 	);
 
 	/**
-	 * 주어진 인기 키워드 ID 목록과 플랫폼에 해당하는 Source 엔티티들을
-	 * 관련 관계(keyword_metric_hourly -> post -> post_source -> source)를 따라 조회하고
-	 * 페이지네이션 및 인기순(키워드 점수 등) 정렬을 적용하여 반환합니다.
-	 * @param topKeywordIds 인기 키워드의 ID 목록.
-	 * @param platform 조회할 플랫폼 (YOUTUBE 또는 NAVER_NEWS).
-	 * @param pageable 페이지네이션 및 정렬 정보. Service에서 전달한 정렬 정보가 쿼리에 자동 반영됩니다.
-	 * @return 페이지네이션된 Source 엔티티 목록.
-	 */
-	@Query(
-	value = """
-            SELECT DISTINCT s
-            FROM KeywordMetricHourly kmh
-            LEFT JOIN kmh.post p
-            JOIN PostSource ps ON ps.post = p
-            JOIN ps.source s
-            WHERE kmh.id.keywordId IN (:topKeywordIds)
-            AND s.platform = :platform
-            ORDER BY s.publishedAt DESC
-            """,
-	countQuery = """
-			SELECT COUNT(DISTINCT s.fingerprint)
-			FROM KeywordMetricHourly kmh
-			LEFT JOIN kmh.post p
-			JOIN PostSource ps ON ps.post = p
-			JOIN ps.source s
-			WHERE kmh.id.keywordId IN (:topKeywordIds)
-			AND s.platform = :platform
-			""")
-	Page<Source> findSourcesByTopKeywordIdsAndPlatform(
-			@Param("topKeywordIds") List<Long> topKeywordIds,
-			@Param("platform") Platform platform,
-			Pageable pageable
-	);
-
-	/**
 	 * 실시간 인기 키워드 ID와 플랫폼 기반으로, 출처(Source) 정보를 score 기준 내림차순 정렬하여 DTO로 조회.
 	 * DISTINCT 문제 해결을 위해 SELECT new 사용.
 	 */
-	@Query("""
-            SELECT new site.kkokkio.domain.source.dto.TopSourceItemDto(
-            	s.fingerprint,
-                s.normalizedUrl,
-                s.title,
-                s.description,
-                s.thumbnailUrl,
-                s.publishedAt,
-                s.platform,
-                kmh.score
-                )
-            FROM KeywordMetricHourly kmh
-            LEFT JOIN kmh.post p
-            JOIN PostSource ps
-            ON ps.post = p
-            JOIN ps.source s
-            WHERE kmh.id.keywordId
-            IN (:topKeywordIds)
-                AND s.platform = :platform
-            ORDER BY kmh.score DESC
-            """)
-	Page<TopSourceItemDto> findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-			@Param("topKeywordIds") List<Long> topKeywordIds,
-			@Param("platform") Platform platform,
-			Pageable pageable
+
+	@Query(value = """
+		SELECT new site.kkokkio.domain.source.dto.TopSourceItemDto(
+		    s.fingerprint,
+		    s.normalizedUrl,
+		    s.title,
+		    s.description,
+		    s.thumbnailUrl,
+		    s.publishedAt,
+		    s.platform,
+		    MAX(kmh.score)
+		)
+		FROM KeywordMetricHourly kmh
+		JOIN PostSource ps ON ps.post = kmh.post
+		JOIN ps.source s
+		WHERE kmh.post.id IN :postIds
+		  AND s.platform = :platform
+		GROUP BY
+		    s.fingerprint,
+		    s.normalizedUrl,
+		    s.title,
+		    s.description,
+		    s.thumbnailUrl,
+		    s.publishedAt,
+		    s.platform
+		ORDER BY MAX(kmh.score) DESC
+		""",
+		countQuery = """
+			SELECT COUNT(DISTINCT s.fingerprint)
+			FROM KeywordMetricHourly kmh
+			JOIN PostSource ps      ON ps.post = kmh.post
+			JOIN ps.source          s
+			WHERE kmh.post.id   IN :postIds
+			  AND s.platform      = :platform
+			"""
+	)
+	Page<TopSourceItemDto> findTopSourcesByPostIdsAndPlatformOrderedByScore(
+		@Param("postIds") List<Long> postIds,
+		@Param("platform") Platform platform,
+		Pageable pageable
 	);
 }

--- a/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
+++ b/backend/src/main/java/site/kkokkio/domain/source/service/SourceService.java
@@ -154,12 +154,10 @@ public class SourceService {
 	 */
 	@Transactional
 	public void searchYoutube() {
-		log.info(">>>>>>> searchYoutube 메소드 시작");
-
 		// 1. 최신 Top10 키워드 조회
 		List<KeywordMetricHourlyDto> topKeywords = keywordMetricHourlyService.findHourlyMetrics();
-		List<Source> allSourcesToSave = new ArrayList<>();
-		List<KeywordSource> allKeywordSourcesToSave = new ArrayList<>();
+		List<Source> sources = new ArrayList<>();
+		List<KeywordSource> keywordSources = new ArrayList<>();
 
 		// 2. 키워드별 영상 검색 및 Entity 변환
 		for (KeywordMetricHourlyDto metric : topKeywords) {
@@ -171,8 +169,7 @@ public class SourceService {
 					videoApi.fetchVideos(text, MAX_SOURCE_COUNT_PER_POST)
 							.onErrorResume(e -> {
 								// API 호출 실패 시 로그 기록 및 빈 목록 반환하여 전체 중단 방지
-								log.error("Youtube API 실패. keyword={}, error={}",
-										text, e.toString());
+								log.error("Youtube API 실패. keyword={}, error={}", text, e.toString());
 								return Mono.just(Collections.emptyList());
 							}).block()
 			).orElseGet(Collections::emptyList);
@@ -186,10 +183,10 @@ public class SourceService {
 			for (VideoDto video : videoList) {
 				// VideoDto를 Source 엔티티로 변환
 				Source src = video.toEntity(VIDEO_PLATFORM);
-				allSourcesToSave.add(src); // Source 리스트에 추가
+				sources.add(src); // Source 리스트에 추가
 
 				// Keyword와 Source 연결하는 KeywordSource 엔티티 생성
-				allKeywordSourcesToSave.add(KeywordSource.builder()
+				keywordSources.add(KeywordSource.builder()
 						.keyword(keywordRef)
 						.source(src)
 						.build()
@@ -198,40 +195,24 @@ public class SourceService {
 		}
 
 		// 3. 저장할 데이터가 있는지 확인
-		if (allSourcesToSave.isEmpty()) {
+		if (sources.isEmpty()) {
 			log.info("저장할 Youtube Source가 없습니다.");
 			return; // 저장할 데이터 없으면 종료
 		}
 
 		// 4. Source 리스트에서 중복 제거 (Optional)
-		List<Source> distinctSources = allSourcesToSave.stream().distinct().toList();
-		log.info("처리할 중복 제거된 Source {}개", distinctSources.size());
+		List<Source> distinctSources = sources.stream().distinct().toList();
 
 		// 5. Source 데이터 저장 (INSERT IGNORE 사용)
 		// sourceRepositoryCustom는 @Autowired 필요
 		sourceRepository.insertIgnoreAll(distinctSources);
-		log.info("{}개의 Youtube Source 저장 시도 (INSERT IGNORE 사용)", distinctSources.size());
 
 		// 6. KeywordSource 데이터 저장 (INSERT IGNORE 사용)
-		// distinctSources에 있는 Source의 fingerprint를 기준으로 allKeywordSourcesToSave를 필터링
-		// distinct() 과정에서 제거된 Source와 연결된 KeywordSource는 저장 대상에서 제외
-		List<String> distinctSourceFingerprints = distinctSources.stream()
-				.map(Source::getFingerprint).toList();
-		List<KeywordSource> distinctKeywordSources = allKeywordSourcesToSave.stream()
-						.filter(ks -> ks.getSource() != null &&
-								ks.getSource().getFingerprint() != null &&
-								distinctSourceFingerprints.contains(ks.getSource()
-										.getFingerprint())).toList();
-
 		// keywordSourceRepository는 @Autowired 필요
-		keywordSourceRepository.insertIgnoreAll(distinctKeywordSources);
-		log.info(">>> {}개의 KeywordSource 저장 시도 (INSERT IGNORE 사용)",
-				distinctSourceFingerprints.size());
+		keywordSourceRepository.insertIgnoreAll(keywordSources);
 
 		// 7. OpenGraph 정보 비동기 보강 (Source 엔티티에 URL 필드 필요)
 		distinctSources.forEach(openGraphService::enrichAsync);
-
-		log.info(">>>>>>> searchYoutube 메소드 완료");
 	}
 
 	/**

--- a/backend/src/main/java/site/kkokkio/global/config/WebClientConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/WebClientConfig.java
@@ -1,6 +1,5 @@
 package site.kkokkio.global.config;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,9 +13,9 @@ public class WebClientConfig {
     public WebClient naverWebClient(
             @Value("${naver.base-url}") String baseUrl) {
         return WebClient.builder()
-                .baseUrl(baseUrl)
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
     }
 
     /**
@@ -26,16 +25,16 @@ public class WebClientConfig {
      * @return Youtube API 호출용 WebClient
      */
     @Bean
-    @Qualifier("youtubeWebClient")
     public WebClient youtubeWebClient(
             @Value("${youtube.api.base-url}") String baseUrl
     ) {
         return WebClient.builder()
-                // YouTube API는 API 키를 주로 쿼리 파라미터로 사용하므로,
-                // defaultHeader에 API 키를 추가하는 것보다 어댑터에서
-                // 직접 쿼리 파라미터로 추가하는 방식이 더 일반적임
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .build();
+            // YouTube API는 API 키를 주로 쿼리 파라미터로 사용하므로,
+            // defaultHeader에 API 키를 추가하는 것보다 어댑터에서
+            // 직접 쿼리 파라미터로 추가하는 방식이 더 일반적임
+            .baseUrl(baseUrl)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build();
     }
 
 }

--- a/backend/src/test/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/keyword/controller/KeywordMetricHourlyControllerV1Test.java
@@ -49,7 +49,7 @@ public class KeywordMetricHourlyControllerV1Test {
 		LocalDateTime now = LocalDateTime.now();
 		for (long i = 1; i <= 10; i++) {
 			mockKeywordList.add(
-				new KeywordMetricHourlyDto(i, "키워드 " + i, Platform.GOOGLE_TREND, now, 100, 100, false)
+				new KeywordMetricHourlyDto(i, "키워드 " + i, Platform.GOOGLE_TREND, now, 100, 100, false, null)
 			);
 		}
 
@@ -61,7 +61,6 @@ public class KeywordMetricHourlyControllerV1Test {
 			.andExpect(jsonPath("$.message").value("실시간 키워드를 불러왔습니다."))
 			.andExpect(jsonPath("$.data[0].text").value("키워드 1"))
 			.andExpect(jsonPath("$.data[0].platform").value("GOOGLE_TREND"))
-			.andExpect(jsonPath("$.data[0].volume").value(100))
 			.andExpect(jsonPath("$.data[0].score").value(100));
 	}
 

--- a/backend/src/test/java/site/kkokkio/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/post/service/PostServiceTest.java
@@ -10,8 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +18,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import site.kkokkio.domain.keyword.dto.KeywordMetricHourlyDto;
 import site.kkokkio.domain.keyword.entity.Keyword;
@@ -167,7 +167,7 @@ public class PostServiceTest {
 		String KeywordText = "키워드";
 
 		KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId, KeywordText, Platform.GOOGLE_TREND,
-			bucketAt, 0, 0, false);
+			bucketAt, 0, 0, false, null);
 		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(List.of(metric));
 
 		Keyword keyword = Keyword.builder().id(keywordId).text(KeywordText).build();
@@ -208,7 +208,7 @@ public class PostServiceTest {
 		Long keywordId = 1L;
 		LocalDateTime bucketAt = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
 		KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId, "chatgpt", Platform.GOOGLE_TREND,
-			bucketAt, 0, 0, true);
+			bucketAt, 0, 0, true, 999L);
 		Keyword keyword = Keyword.builder().id(keywordId).text("chatgpt").build();
 		Source source = createSource("http://example.com");
 
@@ -246,7 +246,7 @@ public class PostServiceTest {
 		Long keywordId = 1L;
 		LocalDateTime now = LocalDateTime.of(2025, 5, 1, 0, 0);
 		KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId, "없음", Platform.GOOGLE_TREND, now, 0, 0,
-			false);
+			false, null);
 
 		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(List.of(metric));
 		given(keywordSourceRepository.findTopSourcesByKeywordIdsLimited(List.of(keywordId), 10)).willReturn(List.of());

--- a/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/controller/SourceControllerV1Test.java
@@ -24,7 +24,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import site.kkokkio.domain.source.controller.dto.TopSourceListResponse;
 import site.kkokkio.domain.source.dto.SourceDto;
 import site.kkokkio.domain.source.dto.TopSourceItemDto;
 import site.kkokkio.domain.source.service.SourceService;
@@ -37,367 +36,362 @@ import site.kkokkio.global.util.JwtUtils;
 @AutoConfigureMockMvc(addFilters = false)
 class SourceControllerV1Test {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @MockitoBean
-    private SourceService sourceService;
+	@MockitoBean
+	private SourceService sourceService;
 
-    @MockitoBean
-    private CustomUserDetailsService customUserDetailsService;
+	@MockitoBean
+	private CustomUserDetailsService customUserDetailsService;
 
-    @MockitoBean
-    private RedisTemplate<String, String> redisTemplate;
+	@MockitoBean
+	private RedisTemplate<String, String> redisTemplate;
 
-    @MockitoBean
-    private JwtUtils jwtUtils;
+	@MockitoBean
+	private JwtUtils jwtUtils;
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 성공")
-    void getNewsSources_Success() throws Exception {
-        // given
-        List<SourceDto> mockNewsList = List.of(
-                new SourceDto("source-1", "https://news.com", "https://image.jpg", "뉴스 제목1", LocalDateTime.parse("2024-04-29T15:30:00"),
-                        Platform.NAVER_NEWS),
-                new SourceDto("source-2", "https://news.com", "https://image.jpg", "뉴스 제목2", LocalDateTime.parse("2024-04-29T15:30:00"),
-                        Platform.NAVER_NEWS),
-                new SourceDto("source-3", "https://news.com", "https://image.jpg", "뉴스 제목3", LocalDateTime.parse("2024-04-29T15:30:00"),
-                        Platform.NAVER_NEWS),
-                new SourceDto("source-4", "https://news.com", "https://image.jpg", "뉴스 제목4", LocalDateTime.parse("2024-04-29T15:30:00"),
-                        Platform.NAVER_NEWS),
-                new SourceDto("source-5", "https://news.com", "https://image.jpg", "뉴스 제목5", LocalDateTime.parse("2024-04-29T15:30:00"),
-                        Platform.NAVER_NEWS)
-        );
-        given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(mockNewsList);
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 성공")
+	void getNewsSources_Success() throws Exception {
+		// given
+		List<SourceDto> mockNewsList = List.of(
+			new SourceDto("source-1", "https://news.com", "https://image.jpg", "뉴스 제목1",
+				LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("source-2", "https://news.com", "https://image.jpg", "뉴스 제목2",
+				LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("source-3", "https://news.com", "https://image.jpg", "뉴스 제목3",
+				LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("source-4", "https://news.com", "https://image.jpg", "뉴스 제목4",
+				LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS),
+			new SourceDto("source-5", "https://news.com", "https://image.jpg", "뉴스 제목5",
+				LocalDateTime.parse("2024-04-29T15:30:00"),
+				Platform.NAVER_NEWS)
+		);
+		given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(mockNewsList);
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-1"))
-                .andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
-                .andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+			.andExpect(jsonPath("$.data.list[0].sourceId").value("source-1"))
+			.andExpect(jsonPath("$.data.list[0].url").value("https://news.com"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
+			.andExpect(jsonPath("$.data.list[0].title").value("뉴스 제목1"));
+	}
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 데이터 없음")
-    void getNewsSources_EmptyList() throws Exception {
-        // given
-        given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(List.of());
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 데이터 없음")
+	void getNewsSources_EmptyList() throws Exception {
+		// given
+		given(sourceService.getTop10NewsSourcesByPostId(anyLong())).willReturn(List.of());
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-                .andExpect(jsonPath("$.data.list").isEmpty());
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+			.andExpect(jsonPath("$.data.list").isEmpty());
+	}
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 잘못된 요청")
-    void getNewsSources_InvalidPostId_BadRequest() throws Exception {
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", "invalidId"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.code").value("400"))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
-    }
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 잘못된 요청")
+	void getNewsSources_InvalidPostId_BadRequest() throws Exception {
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", "invalidId"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("400"))
+			.andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+	}
 
-    @Test
-    @DisplayName("포스트의 출처 뉴스 조회 - 포스트 없음")
-    void getNewsSources_PostNotFound() throws Exception {
-        // given
-        given(sourceService.getTop10NewsSourcesByPostId(anyLong()))
-                .willThrow(new ServiceException("404", "해당 포스트를 찾을 수 없습니다."));
+	@Test
+	@DisplayName("포스트의 출처 뉴스 조회 - 포스트 없음")
+	void getNewsSources_PostNotFound() throws Exception {
+		// given
+		given(sourceService.getTop10NewsSourcesByPostId(anyLong()))
+			.willThrow(new ServiceException("404", "해당 포스트를 찾을 수 없습니다."));
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/news", 999L))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value("404"))
-                .andExpect(jsonPath("$.message").value("해당 포스트를 찾을 수 없습니다."));
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/news", 999L))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("404"))
+			.andExpect(jsonPath("$.message").value("해당 포스트를 찾을 수 없습니다."));
+	}
 
-    @Test
-    @DisplayName("포스트의 출처 영상 조회 - 성공")
-    void getVideoSources_Success() throws Exception {
-        // given
-        List<SourceDto> mockVideoList = List.of(
-                new SourceDto("source-1", "https://youtube.com", "https://image.jpg", "영상 제목1",
-                        LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("source-2", "https://youtube.com", "https://image.jpg", "영상 제목2",
-                        LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("source-3", "https://youtube.com", "https://image.jpg", "영상 제목3",
-                        LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("source-4", "https://youtube.com", "https://image.jpg", "영상 제목4",
-                        LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
-                new SourceDto("source-5", "https://youtube.com", "https://image.jpg", "영상 제목5",
-                        LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE)
-        );
-        given(sourceService.getTop10VideoSourcesByPostId(anyLong())).willReturn(mockVideoList);
+	@Test
+	@DisplayName("포스트의 출처 영상 조회 - 성공")
+	void getVideoSources_Success() throws Exception {
+		// given
+		List<SourceDto> mockVideoList = List.of(
+			new SourceDto("source-1", "https://youtube.com", "https://image.jpg", "영상 제목1",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("source-2", "https://youtube.com", "https://image.jpg", "영상 제목2",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("source-3", "https://youtube.com", "https://image.jpg", "영상 제목3",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("source-4", "https://youtube.com", "https://image.jpg", "영상 제목4",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE),
+			new SourceDto("source-5", "https://youtube.com", "https://image.jpg", "영상 제목5",
+				LocalDateTime.parse("2024-04-29T15:30:00"), Platform.YOUTUBE)
+		);
+		given(sourceService.getTop10VideoSourcesByPostId(anyLong())).willReturn(mockVideoList);
 
-        // when & then
-        mockMvc.perform(get("/api/v1/posts/{postId}/videos", 1L))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
-                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-1"))
-                .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
-                .andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
-    }
+		// when & then
+		mockMvc.perform(get("/api/v1/posts/{postId}/videos", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("성공적으로 조회되었습니다."))
+			.andExpect(jsonPath("$.data.list[0].sourceId").value("source-1"))
+			.andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.jpg"))
+			.andExpect(jsonPath("$.data.list[0].title").value("영상 제목1"));
+	}
 
-    @Test
-    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
-    void getTopYoutubeSources_Success() throws Exception {
+	@Test
+	@DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 성공")
+	void getTopYoutubeSources_Success() throws Exception {
 
-        /// given
-        // Mocking 할 서비스 메소드의 반환 값 생성
-        List<TopSourceItemDto> mockItemList = List.of(
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-1")
-                        .url("https://youtube.com/watch?v=video1")
-                        .title("유튜브 인기 영상 제목 1")
-                        .description(null)
-                        .thumbnailUrl("https://image.youtube1.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
-                        .platform(Platform.YOUTUBE)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-2")
-                        .url("https://youtube.com/watch?v=video2")
-                        .title("유튜브 인기 영상 제목 2")
-                        .description(null)
-                        .thumbnailUrl("https://image.youtube2.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
-                        .platform(Platform.YOUTUBE)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-3")
-                        .url("https://youtube.com/watch?v=video3")
-                        .title("유튜브 인기 영상 제목 3")
-                        .description(null)
-                        .thumbnailUrl("https://image.youtube3.jpg")
-                        .publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
-                        .platform(Platform.YOUTUBE)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-4")
-                        .url("https://youtube.com/watch?v=video4")
-                        .title("유튜브 인기 영상 제목 4")
-                        .description(null)
-                        .thumbnailUrl("https://image.youtube4.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
-                        .platform(Platform.YOUTUBE)
-                        .build()
-        );
+		/// given
+		// Mocking 할 서비스 메소드의 반환 값 생성
+		List<TopSourceItemDto> mockItemList = List.of(
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-1")
+				.url("https://youtube.com/watch?v=video1")
+				.title("유튜브 인기 영상 제목 1")
+				.description(null)
+				.thumbnailUrl("https://image.youtube1.jpg")
+				.publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
+				.platform(Platform.YOUTUBE)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-2")
+				.url("https://youtube.com/watch?v=video2")
+				.title("유튜브 인기 영상 제목 2")
+				.description(null)
+				.thumbnailUrl("https://image.youtube2.jpg")
+				.publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
+				.platform(Platform.YOUTUBE)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-3")
+				.url("https://youtube.com/watch?v=video3")
+				.title("유튜브 인기 영상 제목 3")
+				.description(null)
+				.thumbnailUrl("https://image.youtube3.jpg")
+				.publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
+				.platform(Platform.YOUTUBE)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-4")
+				.url("https://youtube.com/watch?v=video4")
+				.title("유튜브 인기 영상 제목 4")
+				.description(null)
+				.thumbnailUrl("https://image.youtube4.jpg")
+				.publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
+				.platform(Platform.YOUTUBE)
+				.build()
+		);
 
-        // Mocking할 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, mockItemList.size());
+		// Mocking할 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, mockItemList.size());
 
-        // Mocking할 최종 반환 객체 TopSourceListResponse 생성
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
+		// sousourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopSourcesByPlatform(any(Pageable.class), eq(Platform.YOUTUBE)))
+			.willReturn(mockPage);
 
-        // sousourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopYoutubeSources(any(Pageable.class)))
-                .willReturn(mockResponse);
+		/// when & then
+		// /api/v1/videos/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/videos/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        /// when & then
-        // /api/v1/videos/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/videos/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
-                .andExpect(jsonPath("$.data.meta").exists())
+			// 첫번째 값 검증
+			.andExpect(jsonPath("$.data.list[0].sourceId").value("source-commentId-1"))
+			.andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
+			.andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
+			.andExpect(jsonPath("$.data.list[0].description").value(nullValue()))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.youtube1.jpg"))
+			.andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
+			.andExpect(jsonPath("$.data.list[0].platform").value("YOUTUBE"))
 
-                // 첫번째 값 검증
-                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-commentId-1"))
-                .andExpect(jsonPath("$.data.list[0].url").value("https://youtube.com/watch?v=video1"))
-                .andExpect(jsonPath("$.data.list[0].title").value("유튜브 인기 영상 제목 1"))
-                .andExpect(jsonPath("$.data.list[0].description").value(nullValue()))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.youtube1.jpg"))
-                .andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
-                .andExpect(jsonPath("$.data.list[0].platform").value("YOUTUBE"))
+			// data.meta 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
+	}
 
-                // data.meta 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
-    }
+	@Test
+	@DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 데이터 없음")
+	void getTopYoutubeSources_EmptyList() throws Exception {
 
-    @Test
-    @DisplayName("실시간 인기 유튜브 비디오 목록 조회 - 데이터 없음")
-    void getTopYoutubeSources_EmptyList() throws Exception {
+		/// given
+		// Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
 
-        /// given
-        // Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
+		// sourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopSourcesByPlatform(any(Pageable.class), eq(Platform.YOUTUBE))).willReturn(
+			mockEmptyPage);
 
-        // Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
+		/// when & then
+		// /api/v1/videos/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/videos/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list").isEmpty())
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        // sourceService.getTopYoutubeSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopYoutubeSources(any(Pageable.class))).willReturn(mockResponse);
+			// data.met 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));
+		;
+	}
 
-        /// when & then
-        // /api/v1/videos/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/videos/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list").isEmpty())
-                .andExpect(jsonPath("$.data.meta").exists())
+	@Test
+	@DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 성공")
+	void getTopNaverNewsSources_Success() throws Exception {
 
-                // data.met 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));
-        ;
-    }
+		/// given
+		// Mocking 할 서비스 메소드의 반환 값 생성
+		List<TopSourceItemDto> mockItemList = List.of(
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-1")
+				.url("https://news.naver.com/article/1")
+				.title("네이버 인기 뉴스 제목 1")
+				.description("네이버 요약 뉴스 내용 1")
+				.thumbnailUrl("https://image.naver.com/1.jpg")
+				.publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
+				.platform(Platform.NAVER_NEWS)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-2")
+				.url("https://news.naver.com/article/2")
+				.title("네이버 인기 뉴스 제목 2")
+				.description("네이버 요약 뉴스 내용 2")
+				.thumbnailUrl("https://image.naver.com/2.jpg")
+				.publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
+				.platform(Platform.NAVER_NEWS)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-3")
+				.url("https://news.naver.com/article/3")
+				.title("네이버 인기 뉴스 제목 3")
+				.description("네이버 요약 뉴스 내용 3")
+				.thumbnailUrl("https://image.naver.com/3.jpg")
+				.publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
+				.platform(Platform.NAVER_NEWS)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-commentId-4")
+				.url("https://news.naver.com/article/4")
+				.title("네이버 인기 뉴스 제목 4")
+				.description("네이버 요약 뉴스 내용 4")
+				.thumbnailUrl("https://image.naver.com/4.jpg")
+				.publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
+				.platform(Platform.NAVER_NEWS)
+				.build()
+		);
 
-    @Test
-    @DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 성공")
-    void getTopNaverNewsSources_Success() throws Exception {
+		// Mocking할 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, mockItemList.size());
 
-        /// given
-        // Mocking 할 서비스 메소드의 반환 값 생성
-        List<TopSourceItemDto> mockItemList = List.of(
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-1")
-                        .url("https://news.naver.com/article/1")
-                        .title("네이버 인기 뉴스 제목 1")
-                        .description("네이버 요약 뉴스 내용 1")
-                        .thumbnailUrl("https://image.naver.com/1.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-04-29T15:30:00"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-2")
-                        .url("https://news.naver.com/article/2")
-                        .title("네이버 인기 뉴스 제목 2")
-                        .description("네이버 요약 뉴스 내용 2")
-                        .thumbnailUrl("https://image.naver.com/2.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-02-04T18:30:00"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-3")
-                        .url("https://news.naver.com/article/3")
-                        .title("네이버 인기 뉴스 제목 3")
-                        .description("네이버 요약 뉴스 내용 3")
-                        .thumbnailUrl("https://image.naver.com/3.jpg")
-                        .publishedAt(LocalDateTime.parse("2022-02-06T01:11:30"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build(),
-                TopSourceItemDto.builder()
-                        .sourceId("source-commentId-4")
-                        .url("https://news.naver.com/article/4")
-                        .title("네이버 인기 뉴스 제목 4")
-                        .description("네이버 요약 뉴스 내용 4")
-                        .thumbnailUrl("https://image.naver.com/4.jpg")
-                        .publishedAt(LocalDateTime.parse("2024-09-20T19:53:28"))
-                        .platform(Platform.NAVER_NEWS)
-                        .build()
-        );
+		// sousourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopSourcesByPlatform(any(Pageable.class), eq(Platform.NAVER_NEWS)))
+			.willReturn(mockPage);
 
-        // Mocking할 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockPage = new PageImpl<>(mockItemList, mockPageable, mockItemList.size());
+		/// when & then
+		// /api/v1/news/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/news/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        // Mocking할 최종 반환 객체 TopSourceListResponse 생성
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockPage);
+			// 첫번째 값 검증
+			.andExpect(jsonPath("$.data.list[0].sourceId").value("source-commentId-1"))
+			.andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
+			.andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
+			.andExpect(jsonPath("$.data.list[0].description").value("네이버 요약 뉴스 내용 1"))
+			.andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.naver.com/1.jpg"))
+			.andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
+			.andExpect(jsonPath("$.data.list[0].platform").value("NAVER_NEWS"))
 
-        // sousourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopNaverNewsSources(any(Pageable.class)))
-                .willReturn(mockResponse);
+			// data.meta 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
+	}
 
-        /// when & then
-        // /api/v1/news/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/news/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list.length()").value(mockItemList.size()))
-                .andExpect(jsonPath("$.data.meta").exists())
+	@Test
+	@DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 데이터 없음")
+	void getTopNaverNewsSources_EmptyList() throws Exception {
 
-                // 첫번째 값 검증
-                .andExpect(jsonPath("$.data.list[0].sourceId").value("source-commentId-1"))
-                .andExpect(jsonPath("$.data.list[0].url").value("https://news.naver.com/article/1"))
-                .andExpect(jsonPath("$.data.list[0].title").value("네이버 인기 뉴스 제목 1"))
-                .andExpect(jsonPath("$.data.list[0].description").value("네이버 요약 뉴스 내용 1"))
-                .andExpect(jsonPath("$.data.list[0].thumbnailUrl").value("https://image.naver.com/1.jpg"))
-                .andExpect(jsonPath("$.data.list[0].publishedAt").value("2024-04-29T15:30:00"))
-                .andExpect(jsonPath("$.data.list[0].platform").value("NAVER_NEWS"))
+		/// given
+		// Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
+		Pageable mockPageable =
+			PageRequest.of(0, 5, Sort.by("score").descending());
+		Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
 
-                // data.meta 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockPage.hasPrevious()));
-    }
+		// sourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
+		// 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
+		given(sourceService.getTopSourcesByPlatform(any(Pageable.class), eq(Platform.NAVER_NEWS))).willReturn(
+			mockEmptyPage);
 
-    @Test
-    @DisplayName("실시간 인기 네이버 뉴스 목록 조회 - 데이터 없음")
-    void getTopNaverNewsSources_EmptyList() throws Exception {
+		/// when & then
+		// /api/v1/news/top 엔드포인트로 GET 요청
+		mockMvc.perform(get("/api/v1/news/top"))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("200"))
+			.andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
+			.andExpect(jsonPath("$.data").exists())
+			.andExpect(jsonPath("$.data.list").isArray())
+			.andExpect(jsonPath("$.data.list").isEmpty())
+			.andExpect(jsonPath("$.data.meta").exists())
 
-        /// given
-        // Service가 반환할 비어있는 Page<TopSourceItemDto> 객체 생성
-        Pageable mockPageable =
-                PageRequest.of(0, 5, Sort.by("score").descending());
-        Page<TopSourceItemDto> mockEmptyPage = Page.empty(mockPageable);
-
-        // Service가 반환할 최종 응답 객체 (비어있는 목록 포함)
-        TopSourceListResponse mockResponse = TopSourceListResponse.from(mockEmptyPage);
-
-        // sourceService.getTopNaverNewsSources() 메소드가 어떤 Pageable 객체를 받든
-        // 위에서 만든 비어있는 mockResponse 객체를 반환하도록 Mocking 설정
-        given(sourceService.getTopNaverNewsSources(any(Pageable.class))).willReturn(mockResponse);
-
-        /// when & then
-        // /api/v1/news/top 엔드포인트로 GET 요청
-        mockMvc.perform(get("/api/v1/news/top"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value("200"))
-                .andExpect(jsonPath("$.message").value("정상적으로 호출되었습니다."))
-                .andExpect(jsonPath("$.data").exists())
-                .andExpect(jsonPath("$.data.list").isArray())
-                .andExpect(jsonPath("$.data.list").isEmpty())
-                .andExpect(jsonPath("$.data.meta").exists())
-
-                // data.met 필드 값 검증
-                .andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
-                .andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
-                .andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
-                .andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
-                .andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
-                .andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));
-    }
+			// data.met 필드 값 검증
+			.andExpect(jsonPath("$.data.meta.page").value(mockEmptyPage.getNumber()))
+			.andExpect(jsonPath("$.data.meta.size").value(mockEmptyPage.getSize()))
+			.andExpect(jsonPath("$.data.meta.totalElements").value(mockEmptyPage.getTotalElements()))
+			.andExpect(jsonPath("$.data.meta.totalPages").value(mockEmptyPage.getTotalPages()))
+			.andExpect(jsonPath("$.data.meta.hasNext").value(mockEmptyPage.hasNext()))
+			.andExpect(jsonPath("$.data.meta.hasPrevious").value(mockEmptyPage.hasPrevious()));
+	}
 }

--- a/backend/src/test/java/site/kkokkio/domain/source/service/SourceServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/source/service/SourceServiceTest.java
@@ -51,930 +51,1092 @@ import site.kkokkio.infra.common.exception.RetryableExternalApiException;
 @ExtendWith(MockitoExtension.class)
 class SourceServiceTest {
 
-    @InjectMocks
-    private SourceService sourceService;
-
-    @Mock
-    private PostService postService;
-    @Mock
-    private PostSourceRepository postSourceRepository;
-    @Mock
-    private SourceRepository sourceRepository;
-    @Mock
-    private NewsApiPort newsApi;
-    @Mock
-    private VideoApiPort videoApi;
-    @Mock
-    private KeywordMetricHourlyService keywordMetricHourlyService;
-    @Mock
-    private OpenGraphService openGraphService;
-    @Mock
-    private KeywordSourceRepository keywordSourceRepository;
-
-
-    private List<Source> newsSources;
-    private List<PostSource> newsPostSources;
-    private List<Source> youtubeSources;
-    private List<PostSource> youtubePostSources;
-    private Long postId = 1L;
-    private Post dummyPost;
-
-    @BeforeEach
-    void setUp() {
-        dummyPost = Post.builder().id(postId).build();
-        newsSources = Arrays.asList(
-                Source.builder().fingerprint("f1").normalizedUrl("https://news1").title("뉴스1").description("뉴스1 설명")
-                        .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
-                Source.builder().fingerprint("f2").normalizedUrl("https://news2").title("뉴스2").description("뉴스2 설명")
-                        .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
-                Source.builder().fingerprint("f3").normalizedUrl("https://news3").title("뉴스3").description("뉴스3 설명")
-                        .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build()
-        );
-
-        newsPostSources = Arrays.asList(
-                PostSource.builder().id(101L).post(dummyPost).source(newsSources.get(0)).build(),
-                PostSource.builder().id(102L).post(dummyPost).source(newsSources.get(1)).build(),
-                PostSource.builder().id(103L).post(dummyPost).source(newsSources.get(2)).build()
-        );
-        youtubeSources = Arrays.asList(
-                Source.builder().fingerprint("f1").normalizedUrl("https://youtube1").title("유튜브1").description("유튜브1 설명")
-                        .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
-                Source.builder().fingerprint("f2").normalizedUrl("https://youtube2").title("유튜브2").description("유튜브2 설명")
-                        .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
-                Source.builder().fingerprint("f3").normalizedUrl("https://youtube3").title("유튜브3").description("유튜브3 설명")
-                        .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build()
-        );
-
-        youtubePostSources = Arrays.asList(
-                PostSource.builder().id(104L).post(dummyPost).source(youtubeSources.get(0)).build(),
-                PostSource.builder().id(105L).post(dummyPost).source(youtubeSources.get(1)).build(),
-                PostSource.builder().id(106L).post(dummyPost).source(youtubeSources.get(2)).build()
-        );
-    }
-
-    @Test
-    @DisplayName("뉴스 출처 10개 조회 - 성공")
-    void getTop10NewsSourcesByPostId_success() {
-        // given
-        Platform platform = Platform.NAVER_NEWS;
-        PageRequest pageRequest = PageRequest.of(0, 10);
-
-        given(postService.getPostById(eq(postId))).willReturn(dummyPost);
-        given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
-                .willReturn(newsPostSources);
-
-        // when
-        List<SourceDto> result = sourceService.getTop10NewsSourcesByPostId(postId);
-
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).url()).isEqualTo("https://news1");
-        assertThat(result.get(1).title()).isEqualTo("뉴스2");
-    }
-
-    @Test
-    @DisplayName("뉴스 출처 10개 조회 - 데이터 없음")
-    void getTop10NewsSourcesByPostId_emptySourceList() {
-        // given
-        Platform platform = Platform.NAVER_NEWS;
-        PageRequest pageRequest = PageRequest.of(0, 10);
-
-        given(postService.getPostById(eq(postId))).willReturn(dummyPost);
-        given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
-                .willReturn(Collections.emptyList());
-
-        // when
-        List<SourceDto> result = sourceService.getTop10NewsSourcesByPostId(postId);
-
-        // then
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("뉴스 출처 10개 조회 - 포스트 없음")
-    void getTop10NewsSourcesByPostId_postNotFound() {
-        // given
-        Long postId = 999L;
-
-        given(postService.getPostById(postId))
-                .willThrow(new ServiceException("400", "해당 포스트를 찾을 수 없습니다."));
-
-        // when & then
-        assertThatThrownBy(() -> sourceService.getTop10NewsSourcesByPostId(postId))
-                .isInstanceOf(ServiceException.class)
-                .hasMessage("해당 포스트를 찾을 수 없습니다.");
-    }
-
-
-    @Test
-    @DisplayName("영상 출처 10개 조회 - 성공")
-    void getTop10VideoSourcesByPostId_success() {
-        // given
-        Platform platform = Platform.YOUTUBE;
-        PageRequest pageRequest = PageRequest.of(0, 10);
-
-        given(postService.getPostById(eq(postId))).willReturn(dummyPost);
-        given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
-                .willReturn(youtubePostSources);
-
-        // when
-        List<SourceDto> result = sourceService.getTop10VideoSourcesByPostId(postId);
-
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).url()).isEqualTo("https://youtube1");
-        assertThat(result.get(1).title()).isEqualTo("유튜브2");
-    }
-
-    @Test
-    @DisplayName("키워드 검색 소스 조회 - 성공")
-    void getTop10VideoSourcesByPostId_Success() {
-        PostDto post1 = new PostDto(1L, "키워드", "제목1", "설명1", "url1");
-        PostDto post2 = new PostDto(2L, "키워드", "제목2", "설명2", "url2");
-
-        List<PostDto> postDtos = List.of(post1, post2);
-
-        given(sourceRepository.findByPostIdsOrderByPublishedAtDesc(eq(List.of(1L, 2L)), any(PageRequest.class)))
-                .willReturn(newsSources);
-
-        // when
-        List<SourceDto> result = sourceService.getTop5SourcesByPosts(postDtos);
-
-        // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).title()).isEqualTo("뉴스1");
-        assertThat(result.get(1).title()).isEqualTo("뉴스2");
-
-        verify(sourceRepository).findByPostIdsOrderByPublishedAtDesc(eq(List.of(1L, 2L)), any(PageRequest.class));
-    }
-
-
-    @Test
-    @DisplayName("키워드 검색 소스 조회 - 빈 데이터")
-    void getTop10VideoSourcesByPostId_Empty() {
-        // when
-        List<SourceDto> result = sourceService.getTop5SourcesByPosts(Collections.emptyList());
-
-        // then
-        assertThat(result).isEmpty();
-        verifyNoInteractions(sourceRepository);
-    }
-
-
-    @Test
-    @DisplayName("뉴스 검색 - 성공")
-    void searchNews_success() {
-        // given
-        Long keywordId = 1L;
-        String keywordText = "키워드";
-        KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId, keywordText, Platform.GOOGLE_TREND, LocalDateTime.now(), 0, 0, false);
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(List.of(metric));
-
-        NewsDto dto = NewsDto.builder()
-                .title("뉴스 제목")
-                .link("https://example.com/news")
-                .originalLink("https://example.com/origin")
-                .description("뉴스 설명")
-                .pubDate(LocalDateTime.now())
-                .build();
-
-        given(newsApi.fetchNews(eq(keywordText), anyInt(), anyInt(), eq("sim")))
-                .willReturn(Mono.just(List.of(dto)));
-
-        // when
-        sourceService.searchNews();
-
-        // then
-        then(sourceRepository).should().insertIgnoreAll(argThat(sources ->
-                sources.size() == 1 &&
-                        sources.getFirst().getTitle().equals("뉴스 제목")
-        ));
-        then(keywordSourceRepository).should().insertIgnoreAll(argThat(ksList ->
-                ksList.size() == 1 &&
-                        ksList.getFirst().getKeyword().getId().equals(keywordId)
-        ));
-        then(openGraphService).should().enrichAsync(any(Source.class));
-    }
-
-    @Test
-    @DisplayName("뉴스 검색 - Empty 데이터")
-    void searchNews_empty() {
-        // given
-        KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(1L, "키워드",
-                Platform.NAVER_NEWS, LocalDateTime.now(), 0, 0, false);
-        given(keywordMetricHourlyService.findHourlyMetrics())
-                .willReturn(List.of(metric));
-
-        given(newsApi.fetchNews(anyString(), anyInt(), anyInt(), anyString()))
-                .willReturn(Mono.empty());
-
-        // when
-        sourceService.searchNews();
-
-        // then
-        then(sourceRepository).shouldHaveNoInteractions();
-        then(keywordSourceRepository).shouldHaveNoInteractions();
-        then(openGraphService).shouldHaveNoInteractions();
-    }
-
-    @Test
-    @DisplayName("뉴스 검색 - 에러 발생")
-    void searchNews_error() {
-        // given
-        KeywordMetricHourlyDto metric1 = new KeywordMetricHourlyDto(1L, "실패키워드",
-                Platform.NAVER_NEWS, LocalDateTime.now(), 0, 0, false);
-        KeywordMetricHourlyDto metric2 = new KeywordMetricHourlyDto(2L, "정상키워드",
-                Platform.NAVER_NEWS, LocalDateTime.now(), 0, 0, false);
-        given(keywordMetricHourlyService.findHourlyMetrics())
-                .willReturn(List.of(metric1, metric2));
-
-        NewsDto dto = NewsDto.builder()
-                .title("제목1")
-                .link("http://example.com/article")
-                .originalLink("http://example.com/original")
-                .description("설명")
-                .pubDate(LocalDateTime.of(2025, 4, 29, 12, 0))
-                .build();
-
-        given(newsApi.fetchNews(eq("실패키워드"), anyInt(), anyInt(), anyString()))
-                .willReturn(Mono.error(new RetryableExternalApiException(503, "서버 오류")));
-
-        given(newsApi.fetchNews(eq("정상키워드"), anyInt(), anyInt(), anyString()))
-                .willReturn(Mono.just(List.of(dto)));
-
-        // when
-        sourceService.searchNews();
-
-        // then
-        then(sourceRepository).should().insertIgnoreAll(argThat(sources -> {
-            assertThat(sources).hasSize(1);
-            assertThat(sources.getFirst().getTitle()).isEqualTo("제목1");
-            return true;
-        }));
-    }
-
-    @Test
-    @DisplayName("실시간 인기 유튜브 Source 조회 - 성공")
-    void getTopYoutubeSources_Success() {
-
-        /// given
-        // Mocking할 인기 키워드 목록 생성
-        List<KeywordMetricHourlyDto> mockTopKeywords = Arrays.asList(
-                new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 1000, 90, false),
-                new KeywordMetricHourlyDto(2L, "키워드 2", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 800, 70, false),
-                new KeywordMetricHourlyDto(3L, "키워드 3", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 300, 30, false),
-                new KeywordMetricHourlyDto(4L, "키워드 4", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 50, 77, false),
-                new KeywordMetricHourlyDto(5L, "키워드 5", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 650, 70, false),
-                new KeywordMetricHourlyDto(6L, "키워드 6", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 70, 86, false),
-                new KeywordMetricHourlyDto(7L, "키워드 7", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 120, 43, false),
-                new KeywordMetricHourlyDto(8L, "키워드 8", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 665, 86, false),
-                new KeywordMetricHourlyDto(9L, "키워드 9", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 505, 42, false),
-                new KeywordMetricHourlyDto(10L, "키워드 10", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 404, 55, false)
-        );
-
-        // Mocking할 Repository의 반환 값 (Page<TopSourceItemDto>) 생성
-        List<TopSourceItemDto> mockSourceItemDtoList = Arrays.asList(
-                TopSourceItemDto.builder().sourceId("source-id-1").url("http://youtube.com/v1").title("영상제목1").description(null)
-                        .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(90).build(),
-                TopSourceItemDto.builder().sourceId("source-id-2").url("http://youtube.com/v2").title("영상제목2").description(null)
-                        .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(70).build(),
-                TopSourceItemDto.builder().sourceId("source-id-3").url("http://youtube.com/v3").title("영상제목3").description(null)
-                        .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(30).build(),
-                TopSourceItemDto.builder().sourceId("source-id-4").url("http://youtube.com/v4").title("영상제목4").description(null)
-                        .thumbnailUrl("thumb4").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(77).build(),
-                TopSourceItemDto.builder().sourceId("source-id-5").url("http://youtube.com/v5").title("영상제목5").description(null)
-                        .thumbnailUrl("thumb5").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(70).build(),
-                TopSourceItemDto.builder().sourceId("source-id-6").url("http://youtube.com/v6").title("영상제목6").description(null)
-                        .thumbnailUrl("thumb6").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(86).build(),
-                TopSourceItemDto.builder().sourceId("source-id-7").url("http://youtube.com/v7").title("영상제목7").description(null)
-                        .thumbnailUrl("thumb7").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(43).build(),
-                TopSourceItemDto.builder().sourceId("source-id-8").url("http://youtube.com/v8").title("영상제목8").description(null)
-                        .thumbnailUrl("thumb8").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(86).build(),
-                TopSourceItemDto.builder().sourceId("source-id-9").url("http://youtube.com/v9").title("영상제목9").description(null)
-                        .thumbnailUrl("thumb9").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(42).build(),
-                TopSourceItemDto.builder().sourceId("source-id-10").url("http://youtube.com/v10").title("영상제목10").description(null)
-                        .thumbnailUrl("thumb10").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).score(55).build()
-        );
-
-        // Service 메소드에 전달될 Pageable 객체 (컨트롤러에서 넘어올 형태)
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
-
-        // Repository가 반환할 Mock Page<TopSourceItemDto> 객체 생성
-        Page<TopSourceItemDto> mockSourceItemDtoPage = new PageImpl<>(
-                mockSourceItemDtoList, pageable, mockSourceItemDtoList.size());
-
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 mockTopKeywords 반환
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
-
-        // findTopSourcesByKeywordIdsAndPlatformOrderedByScore()를 Mocking
-        given(postSourceRepository.findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                anyList(),
-                eq(Platform.YOUTUBE),
-                eq(pageable)
-        )).willReturn(mockSourceItemDtoPage);
-
-        /// when
-        // 테스트 대상 메소드 호출
-        TopSourceListResponse result = sourceService.getTopYoutubeSources(pageable);
-
-        /// then
-        assertThat(result).isNotNull();
-        assertThat(result.list()).isNotNull().hasSize(mockTopKeywords.size());
-        assertThat(result.meta()).isNotNull();
-
-        // list 안의 TopSourceItemDto 객체들이 올바르게 변환되었는지 검증
-        assertThat(result.list().getFirst().url())
-                .isEqualTo(mockSourceItemDtoList.getFirst().url());
-        assertThat(result.list().getFirst().title())
-                .isEqualTo(mockSourceItemDtoList.getFirst().title());
-        assertThat(result.list().getFirst().description()).isNull();
-        assertThat(result.list().getFirst().thumbnailUrl())
-                .isEqualTo(mockSourceItemDtoList.getFirst().thumbnailUrl());
-        assertThat(result.list().getFirst().publishedAt())
-                .isEqualTo(mockSourceItemDtoList.getFirst().publishedAt());
-        assertThat(result.list().getFirst().platform())
-                .isEqualTo(mockSourceItemDtoList.getFirst().platform());
-        assertThat(result.list().getFirst().score())
-                .isEqualTo(mockSourceItemDtoList.getFirst().score());
-
-        // Mock SourceList의 두 번째 항목도 검증
-        assertThat(result.list().get(1).url())
-                .isEqualTo(mockSourceItemDtoList.get(1).url());
-        assertThat(result.list().get(1).title())
-                .isEqualTo(mockSourceItemDtoList.get(1).title());
-        assertThat(result.list().get(1).description()).isNull();
-        assertThat(result.list().get(1).thumbnailUrl())
-                .isEqualTo(mockSourceItemDtoList.get(1).thumbnailUrl());
-        assertThat(result.list().get(1).publishedAt())
-                .isEqualTo(mockSourceItemDtoList.get(1).publishedAt());
-        assertThat(result.list().get(1).platform())
-                .isEqualTo(mockSourceItemDtoList.get(1).platform());
-
-        // meta 정보가 Mock Page에서 올바르게 변환되었는지 검증
-        assertThat(result.meta().page()).isEqualTo(mockSourceItemDtoPage.getNumber());
-        assertThat(result.meta().size()).isEqualTo(mockSourceItemDtoPage.getSize());
-        assertThat(result.meta().totalElements()).isEqualTo(mockSourceItemDtoPage.getTotalElements());
-        assertThat(result.meta().totalPages()).isEqualTo(mockSourceItemDtoPage.getTotalPages());
-        assertThat(result.meta().hasNext()).isEqualTo(mockSourceItemDtoPage.hasNext());
-        assertThat(result.meta().hasPrevious()).isEqualTo(mockSourceItemDtoPage.hasPrevious());
-
-        // Service 메소드가 의존하는 다른 메소드들을 올바르게 호출했는지 검증
-        verify(keywordMetricHourlyService, times(1))
-                .findHourlyMetrics();
-        verify(postSourceRepository, times(1))
-                .findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                        anyList(),
-                        eq(Platform.YOUTUBE),
-                        eq(pageable)
-                );
-    }
-
-    @Test
-    @DisplayName("실시간 인기 유튜브 Source 조회 - 인기 키워드 목록이 비어있을 때")
-    void getTopYoutubeSources_EmptyKeywords() {
-
-        /// given
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 빈 리스트 반환하도록 Mocking
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(Collections.emptyList());
-
-        // Service 메소드에 전달될 Pageable 객체
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
-
-        /// when
-        // 테스트 대상 메소드 호출
-        TopSourceListResponse result = sourceService.getTopYoutubeSources(pageable);
-
-        /// then
-        assertThat(result).isNotNull();
-        assertThat(result.list()).isNotNull().isEmpty();
-
-        // Page.empty(pageable)이 생성하는 Page 객체의 메타 정보를 기준으로 검증
-        Page<TopSourceItemDto> emptyPage = Page.empty(pageable);
-
-        assertThat(result.meta()).isNotNull();
-        assertThat(result.meta().page()).isEqualTo(emptyPage.getNumber());
-        assertThat(result.meta().size()).isEqualTo(emptyPage.getSize());
-        assertThat(result.meta().totalElements()).isEqualTo(emptyPage.getTotalElements());
-        assertThat(result.meta().totalPages()).isEqualTo(emptyPage.getTotalPages());
-        assertThat(result.meta().hasNext()).isEqualTo(emptyPage.hasNext());
-        assertThat(result.meta().hasPrevious()).isEqualTo(emptyPage.hasPrevious());
-
-        // Service가 Repository 메소드를 호출하지 않았는지 검증
-        verify(postSourceRepository, never()).findSourcesByTopKeywordIdsAndPlatform(
-                anyList(),
-                any(Platform.class),
-                any(Pageable.class)
-        );
-
-        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
-        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
-    }
-
-    @Test
-    @DisplayName("실시간 인기 유튜브 Source 조회 - Repository가 빈 Page를 반환할 때")
-    void getTopYoutubeSources_RepositoryReturnsEmptyPage() {
-
-        /// given
-        // Mocking할 인기 키워드 목록 생성
-        List<KeywordMetricHourlyDto> mockTopKeywords = List.of(
-                new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 1000, 90, false)
-        );
-
-        // Mocking할 Repository의 반환 값 (빈 Page<TopSourceItemDto>) 생성
-        List<TopSourceItemDto> mockEmptySourceList = Collections.emptyList();
-        Pageable pageable = PageRequest.of(
-                0, 10, Sort.by("score").descending());
-
-        // Repository가 반환할 Mock 빈 Page<TopSourceItemDto> 객체 생성
-        Page<TopSourceItemDto> mockEmptySourceItemDtoPage = new PageImpl<>(
-                mockEmptySourceList, pageable, 0);
-
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 비어있지 않은 목록 반환
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
-
-        // findTopSourcesByKeywordIdsAndPlatformOrderedByScore()를 Mocking
-        given(postSourceRepository.findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                anyList(),
-                eq(Platform.YOUTUBE),
-                eq(pageable)
-        )).willReturn(mockEmptySourceItemDtoPage);
-
-        /// when
-        // 테스트 대상 메소드 호출
-        TopSourceListResponse result = sourceService.getTopYoutubeSources(pageable);
-
-        /// then
-        assertThat(result).isNotNull();
-        assertThat(result.list()).isNotNull().isEmpty();
-        assertThat(result.meta()).isNotNull();
-        assertThat(result.meta().page()).isEqualTo(mockEmptySourceItemDtoPage.getNumber());
-        assertThat(result.meta().size()).isEqualTo(mockEmptySourceItemDtoPage.getSize());
-        assertThat(result.meta().totalElements()).isEqualTo(mockEmptySourceItemDtoPage.getTotalElements());
-        assertThat(result.meta().totalPages()).isEqualTo(mockEmptySourceItemDtoPage.getTotalPages());
-        assertThat(result.meta().hasNext()).isEqualTo(mockEmptySourceItemDtoPage.hasNext());
-        assertThat(result.meta().hasPrevious()).isEqualTo(mockEmptySourceItemDtoPage.hasPrevious());
-
-        // Service가 Repository 메소드를 호출했는지 검증 (인기 키워드가 있으므로 호출되어야 함)
-        verify(postSourceRepository, times(1))
-                .findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                        anyList(),
-                        eq(Platform.YOUTUBE),
-                        eq(pageable)
-                );
-
-        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
-        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
-    }
-
-    @Test
-    @DisplayName("실시간 인기 네이버 뉴스 Source 조회 - 성공")
-    void getTopNaverNewsSources_Success() {
-
-        /// given
-        // Mocking할 인기 키워드 목록 생성
-        List<KeywordMetricHourlyDto> mockTopKeywords = Arrays.asList(
-                new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 1000, 90, false),
-                new KeywordMetricHourlyDto(2L, "키워드 2", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 800, 70, false),
-                new KeywordMetricHourlyDto(3L, "키워드 3", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 300, 30, false),
-                new KeywordMetricHourlyDto(4L, "키워드 4", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 50, 77, false),
-                new KeywordMetricHourlyDto(5L, "키워드 5", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 650, 70, false),
-                new KeywordMetricHourlyDto(6L, "키워드 6", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 70, 86, false),
-                new KeywordMetricHourlyDto(7L, "키워드 7", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 120, 43, false),
-                new KeywordMetricHourlyDto(8L, "키워드 8", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 665, 86, false),
-                new KeywordMetricHourlyDto(9L, "키워드 9", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 505, 42, false),
-                new KeywordMetricHourlyDto(10L, "키워드 10", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 404, 55, false)
-        );
-
-        // Mocking할 Repository의 반환 값 (Page<TopSourceItemDto>) 생성
-        List<TopSourceItemDto> mockSourceItemDtoList = Arrays.asList(
-                TopSourceItemDto.builder().sourceId("source-id-1").url("http://news.naver.com/article/1").title("뉴스제목1").description("네이버 뉴스 요약 1")
-                        .thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(90).build(),
-                TopSourceItemDto.builder().sourceId("source-id-2").url("http://news.naver.com/article/2").title("뉴스제목2").description("네이버 뉴스 요약 2")
-                        .thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(70).build(),
-                TopSourceItemDto.builder().sourceId("source-id-3").url("http://news.naver.com/article/3").title("뉴스제목3").description("네이버 뉴스 요약 3")
-                        .thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(30).build(),
-                TopSourceItemDto.builder().sourceId("source-id-4").url("http://news.naver.com/article/4").title("뉴스제목4").description("네이버 뉴스 요약 4")
-                        .thumbnailUrl("thumb4").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(77).build(),
-                TopSourceItemDto.builder().sourceId("source-id-5").url("http://news.naver.com/article/5").title("뉴스제목5").description("네이버 뉴스 요약 5")
-                        .thumbnailUrl("thumb5").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(70).build(),
-                TopSourceItemDto.builder().sourceId("source-id-6").url("http://news.naver.com/article/6").title("뉴스제목6").description("네이버 뉴스 요약 6")
-                        .thumbnailUrl("thumb6").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(86).build(),
-                TopSourceItemDto.builder().sourceId("source-id-7").url("http://news.naver.com/article/7").title("뉴스제목7").description("네이버 뉴스 요약 7")
-                        .thumbnailUrl("thumb7").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(43).build(),
-                TopSourceItemDto.builder().sourceId("source-id-8").url("http://news.naver.com/article/8").title("뉴스제목8").description("네이버 뉴스 요약 8")
-                        .thumbnailUrl("thumb8").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(86).build(),
-                TopSourceItemDto.builder().sourceId("source-id-9").url("http://news.naver.com/article/9").title("뉴스제목9").description("네이버 뉴스 요약 9")
-                        .thumbnailUrl("thumb9").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(42).build(),
-                TopSourceItemDto.builder().sourceId("source-id-10").url("http://news.naver.com/article/10").title("뉴스제목10").description("네이버 뉴스 요약 10")
-                        .thumbnailUrl("thumb10").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).score(55).build()
-        );
-
-        // Service 메소드에 전달될 Pageable 객체 (컨트롤러에서 넘어올 형태)
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
-
-        // Repository가 반환할 Mock Page<TopSourceItemDto> 객체 생성
-        Page<TopSourceItemDto> mockSourceItemDtoPage = new PageImpl<>(
-                mockSourceItemDtoList, pageable, mockSourceItemDtoList.size());
-
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 mockTopKeywords 반환
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
-
-        // findTopSourcesByKeywordIdsAndPlatformOrderedByScore()를 Mocking
-        given(postSourceRepository.findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                anyList(),
-                eq(Platform.NAVER_NEWS),
-                eq(pageable)
-        )).willReturn(mockSourceItemDtoPage);
-
-        /// when
-        // 테스트 대상 메소드 호출
-        TopSourceListResponse result = sourceService.getTopNaverNewsSources(pageable);
-
-        /// then
-        assertThat(result).isNotNull();
-        assertThat(result.list()).isNotNull().hasSize(mockTopKeywords.size());
-        assertThat(result.meta()).isNotNull();
-
-        // list 안의 TopSourceItemDto 객체들이 올바르게 변환되었는지 검증
-        assertThat(result.list().getFirst().url())
-                .isEqualTo(mockSourceItemDtoList.getFirst().url());
-        assertThat(result.list().getFirst().title())
-                .isEqualTo(mockSourceItemDtoList.getFirst().title());
-        assertThat(result.list().getFirst().description())
-                .isEqualTo(mockSourceItemDtoList.getFirst().description());
-        assertThat(result.list().getFirst().thumbnailUrl())
-                .isEqualTo(mockSourceItemDtoList.getFirst().thumbnailUrl());
-        assertThat(result.list().getFirst().publishedAt())
-                .isEqualTo(mockSourceItemDtoList.getFirst().publishedAt());
-        assertThat(result.list().getFirst().platform())
-                .isEqualTo(mockSourceItemDtoList.getFirst().platform());
-        assertThat(result.list().getFirst().score())
-                .isEqualTo(mockSourceItemDtoList.getFirst().score());
-
-        // Mock SourceList의 두 번째 항목도 검증
-        assertThat(result.list().get(1).url())
-                .isEqualTo(mockSourceItemDtoList.get(1).url());
-        assertThat(result.list().get(1).title())
-                .isEqualTo(mockSourceItemDtoList.get(1).title());
-        assertThat(result.list().get(1).description())
-                .isEqualTo(mockSourceItemDtoList.get(1).description());
-        assertThat(result.list().get(1).thumbnailUrl())
-                .isEqualTo(mockSourceItemDtoList.get(1).thumbnailUrl());
-        assertThat(result.list().get(1).publishedAt())
-                .isEqualTo(mockSourceItemDtoList.get(1).publishedAt());
-        assertThat(result.list().get(1).platform())
-                .isEqualTo(mockSourceItemDtoList.get(1).platform());
-        assertThat(result.list().get(1).score())
-                .isEqualTo(mockSourceItemDtoList.get(1).score());
-
-        // meta 정보가 Mock Page에서 올바르게 변환되었는지 검증
-        assertThat(result.meta().page()).isEqualTo(mockSourceItemDtoPage.getNumber());
-        assertThat(result.meta().size()).isEqualTo(mockSourceItemDtoPage.getSize());
-        assertThat(result.meta().totalElements()).isEqualTo(mockSourceItemDtoPage.getTotalElements());
-        assertThat(result.meta().totalPages()).isEqualTo(mockSourceItemDtoPage.getTotalPages());
-        assertThat(result.meta().hasNext()).isEqualTo(mockSourceItemDtoPage.hasNext());
-        assertThat(result.meta().hasPrevious()).isEqualTo(mockSourceItemDtoPage.hasPrevious());
-
-        // Service 메소드가 의존하는 다른 메소드들을 올바르게 호출했는지 검증
-        verify(keywordMetricHourlyService, times(1))
-                .findHourlyMetrics();
-        verify(postSourceRepository, times(1))
-                .findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                        anyList(),
-                        eq(Platform.NAVER_NEWS),
-                        eq(pageable)
-                );
-    }
-
-    @Test
-    @DisplayName("실시간 인기 네이버 뉴스 Source 조회 - 인기 키워드 목록이 비어있을 때")
-    void getTopNaverNewsSources_EmptyKeywords() {
-
-        /// given
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 빈 리스트 반환하도록 Mocking
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(Collections.emptyList());
-
-        // Service 메소드에 전달될 Pageable 객체
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
-
-        /// when
-        // 테스트 대상 메소드 호출
-        TopSourceListResponse result = sourceService.getTopNaverNewsSources(pageable);
-
-        /// then
-        assertThat(result).isNotNull();
-        assertThat(result.list()).isNotNull().isEmpty();
-
-        // Page.empty(pageable)이 생성하는 Page 객체의 메타 정보를 기준으로 검증
-        Page<TopSourceItemDto> emptyPage = Page.empty(pageable);
-
-        assertThat(result.meta()).isNotNull();
-        assertThat(result.meta().page()).isEqualTo(emptyPage.getNumber());
-        assertThat(result.meta().size()).isEqualTo(emptyPage.getSize());
-        assertThat(result.meta().totalElements()).isEqualTo(emptyPage.getTotalElements());
-        assertThat(result.meta().totalPages()).isEqualTo(emptyPage.getTotalPages());
-        assertThat(result.meta().hasNext()).isEqualTo(emptyPage.hasNext());
-        assertThat(result.meta().hasPrevious()).isEqualTo(emptyPage.hasPrevious());
-
-        // Service가 Repository 메소드를 호출하지 않았는지 검증
-        verify(postSourceRepository, never()).findSourcesByTopKeywordIdsAndPlatform(
-                anyList(),
-                any(Platform.class),
-                any(Pageable.class)
-        );
-
-        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
-        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
-    }
-
-    @Test
-    @DisplayName("실시간 인기 네이버 뉴스 Source 조회 - Repository가 빈 Page를 반환할 때")
-    void getTopNaverNewsSources_RepositoryReturnsEmptyPage() {
-
-        /// given
-        // Mocking할 인기 키워드 목록 생성
-        List<KeywordMetricHourlyDto> mockTopKeywords = List.of(
-                new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 1000, 90, false)
-        );
-
-        // Mocking할 Repository의 반환 값 (빈 Page<TopSourceItemDto>) 생성
-        List<TopSourceItemDto> mockEmptySourceItemDtoList = Collections.emptyList();
-        Pageable pageable = PageRequest.of(
-                0, 10, Sort.by("score").descending());
-
-        // Repository가 반환할 Mock 빈 Page<Source> 객체 생성 (내용은 비어있고, 전체 개수는 0)
-        Page<TopSourceItemDto> mockEmptySourceItemDtoPage = new PageImpl<>(
-                mockEmptySourceItemDtoList, pageable, 0);
-
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 시 비어있지 않은 목록 반환
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
-
-        // findTopSourcesByKeywordIdsAndPlatformOrderedByScore()를 Mocking
-        given(postSourceRepository.findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                anyList(),
-                eq(Platform.NAVER_NEWS),
-                eq(pageable)
-        )).willReturn(mockEmptySourceItemDtoPage);
-
-        /// when
-        // 테스트 대상 메소드 호출
-        TopSourceListResponse result = sourceService.getTopNaverNewsSources(pageable);
-
-        /// then
-        assertThat(result).isNotNull();
-        assertThat(result.list()).isNotNull().isEmpty();
-        assertThat(result.meta()).isNotNull();
-        assertThat(result.meta().page()).isEqualTo(mockEmptySourceItemDtoPage.getNumber());
-        assertThat(result.meta().size()).isEqualTo(mockEmptySourceItemDtoPage.getSize());
-        assertThat(result.meta().totalElements()).isEqualTo(mockEmptySourceItemDtoPage.getTotalElements());
-        assertThat(result.meta().totalPages()).isEqualTo(mockEmptySourceItemDtoPage.getTotalPages());
-        assertThat(result.meta().hasNext()).isEqualTo(mockEmptySourceItemDtoPage.hasNext());
-        assertThat(result.meta().hasPrevious()).isEqualTo(mockEmptySourceItemDtoPage.hasPrevious());
-
-        // Service가 Repository 메소드를 호출했는지 검증 (인기 키워드가 있으므로 호출되어야 함)
-        verify(postSourceRepository, times(1))
-                .findTopSourcesByKeywordIdsAndPlatformOrderedByScore(
-                        anyList(),
-                        eq(Platform.NAVER_NEWS),
-                        eq(pageable)
-                );
-
-        // keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
-        verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
-    }
-
-    @Test
-    @DisplayName("Youtube 검색 - 성공")
-    void searchYoutube_success() {
-        /// given
-        Long keywordId1 = 1L;
-        String keywordText1 = "키워드1";
-        Long keywordId2 = 2L;
-        String keywordText2 = "키워드2";
-
-        // Mock: keywordMetricHourlyService.findHourlyMetrics()가 키워드 목록을 반환하도록 설정
-        List<KeywordMetricHourlyDto> topKeywords = Arrays.asList(
-                new KeywordMetricHourlyDto(keywordId1, keywordText1, Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 0, 0, false),
-                new KeywordMetricHourlyDto(keywordId2, keywordText2, Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 0, 0, false)
-        );
-
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(topKeywords);
-
-        // videoApi.fetchVideos()가 각 키워드에 대해 VideoDto 목록을 담은 Mono를 반환하도록 설정
-        // 키워드1에 대한 응답
-        List<VideoDto> video1 = Arrays.asList(
-                VideoDto.builder().url("https://www.youtube.com/watch?v=v1_id_k1").title("영상1 제목 k1").publishedAt(
-                                LocalDateTime.now().minusDays(1)).thumbnailUrl("thumb1_k1")
-                        .description("desc1_k1").build(),
-                VideoDto.builder().url("https://www.youtube.com/watch?v=v2_id_k1").title("영상2 제목 k1").publishedAt(
-                                LocalDateTime.now().minusDays(2)).thumbnailUrl("thumb2_k1")
-                        .description("desc2_k1").build()
-        );
-
-        given(videoApi.fetchVideos(eq(keywordText1), anyInt()))
-                .willReturn(Mono.just(video1));
-
-        // 키워드2에 대한 응답 (일부러 중복되는 영상 포함)
-        List<VideoDto> video2 = Arrays.asList(
-                VideoDto.builder().url("https://www.youtube.com/watch?v=v3_id_k2").title("영상3 제목 k2").publishedAt(
-                                LocalDateTime.now().minusDays(3)).thumbnailUrl("thumb3_k2")
-                        .description("desc3_k2").build(),
-                // 중복 영상
-                VideoDto.builder().url("https://www.youtube.com/watch?v=v2_id_k1").title("영상2 제목 k1").publishedAt(
-                                LocalDateTime.now().minusDays(2)).thumbnailUrl("thumb2_k1")
-                        .description("desc2_k1").build()
-        );
-
-        given(videoApi.fetchVideos(eq(keywordText2), anyInt()))
-                .willReturn(Mono.just(video2));
-
-        // 예상되는 중복 제거된 VideoDto 목록
-        List<VideoDto> expectedDistinctVideoDtos = Arrays.asList(
-                video1.get(0),
-                video1.get(1),
-                video2.get(0)
-        );
-
-        /// when
-        // searchYoutube 메소드 실행
-        sourceService.searchYoutube();
-
-        /// then
-        // 1. videoApi.fetchVideos가 각 키워드에 대해 호출되었는지 검증
-        then(videoApi).should().fetchVideos(eq(keywordText1), anyInt());
-        then(videoApi).should().fetchVideos(eq(keywordText2), anyInt());
-
-        // 2. sourceRepository.insertIgnoreAll 호출 검증
-        // argThat을 사용하여 전달된 리스트의 크기와 내용 검증
-        then(sourceRepository).should().insertIgnoreAll(argThat(sources -> {
-
-            // 저장되는 Source 리스트의 크기 검증
-            assertThat(sources).hasSize(expectedDistinctVideoDtos.size());
-
-            // 저장되는 각 Source 엔티티의 필드 검증
-            assertThat(sources).allSatisfy(source -> {
-                // Service가 VideoDto.toEntity를 호출하여 Source를 만들 때 description이 잘 담기는지 여기서 확인
-                assertThat(source.getDescription()).isNotNull().isNotEmpty();
-
-                // fingerprint 검증: Service 로직대로 fingerprint는 URL 해시이며 null이 아니어야 함
-                assertThat(source.getFingerprint()).isNotNull().isNotEmpty();
-
-                // normalizedUrl 검증: Service 로직대로 normalizedUrl는 VideoDto.id로 구성되며 null이 아니어야 함
-                assertThat(source.getNormalizedUrl()).isNotNull().isNotEmpty();
-
-                assertThat(source.getTitle()).isNotNull().isNotEmpty();
-                assertThat(source.getPublishedAt()).isNotNull();
-                assertThat(source.getPlatform()).isEqualTo(Platform.YOUTUBE);
-            });
-
-            // 저장되는 Source 엔티티들의 fingerprint 집합이 예상되는 distinct Source fingerprint 집합과 일치하는지 확인
-            // 예상되는 fingerprint는 테스트 코드에서 Mock VideoDto.toEntity().getFingerprint()를 호출하여 계산
-            List<String> savedSourceFingerprints = sources.stream()
-                    .map(Source::getFingerprint).toList();
-            List<String> expectedDistinctFingerprints = expectedDistinctVideoDtos.stream()
-                    .map(dto -> dto.toEntity(Platform.YOUTUBE).getFingerprint())
-                    .toList();
-
-            assertThat(savedSourceFingerprints).containsExactlyInAnyOrderElementsOf(expectedDistinctFingerprints);
-
-            return true;
-        }));
-
-        // 3. keywordSourceRepository.insertIgnoreAll 호출 검증
-        then(keywordSourceRepository).should().insertIgnoreAll(argThat(ksList -> {
-            assertThat(ksList).hasSize(4);
-
-            // 리스트에 특정 Keyword ID와 Source fingerprint 조합을 가진 KeywordSource가 포함되어 있는지 확인
-            List<String> ksCominations = ksList.stream()
-                    .map(ks -> ks.getKeyword().getId() + "-" +
-                            ks.getSource().getFingerprint())
-                    .toList();
-            assertThat(ksCominations).containsExactlyInAnyOrder(
-                    keywordId1 + "-" + video1.get(0).toEntity(Platform.YOUTUBE).getFingerprint(),
-                    keywordId1 + "-" + video1.get(1).toEntity(Platform.YOUTUBE).getFingerprint(),
-                    keywordId2 + "-" + video2.get(0).toEntity(Platform.YOUTUBE).getFingerprint(),
-                    keywordId2 + "-" + video2.get(1).toEntity(Platform.YOUTUBE).getFingerprint()
-            );
-            return true;
-        }));
-
-        // 4. openGraphService.enrichAsync 호출 검증
-        // distinctSources 리스트의 각 Source에 대해 호출되었는지 검증
-        then(openGraphService).should(times(3))
-                .enrichAsync(any(Source.class));
-    }
-
-    @Test
-    @DisplayName("Youtube 검색 - API 응답 비어있음")
-    void searchYoutube_emptyApiResponse() {
-        /// given
-        Long keywordId1 = 1L;
-        String keywordText = "빈응답키워드";
-        KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId1, keywordText,
-                Platform.GOOGLE_TREND, LocalDateTime.now(), 0, 0, false);
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(List.of(metric));
-
-        // videoApi.fetchVideos()가 빈 목록을 담은 Mono를 반환하도록 설정
-        given(videoApi.fetchVideos(eq(keywordText), anyInt())).willReturn(Mono.just(List.of()));
-
-        /// when
-        sourceService.searchYoutube();
-
-        /// then
-        // insertIgnoreAll 메소드들이 호출되지 않았는지 검증
-        then(sourceRepository).shouldHaveNoInteractions();
-        then(keywordSourceRepository).shouldHaveNoInteractions();
-        // API 응답 비어있으면 OpenGraph도 호출 안됨
-        then(openGraphService).shouldHaveNoInteractions();
-
-        // keywordMetricHourlyService.findHourlyMetrics()는 호출되었는지 검증
-        then(keywordMetricHourlyService).should(times(1)).findHourlyMetrics();
-        // videoApi.fetchVideos()도 호출되었는지 검증
-        then(videoApi).should(times(1)).fetchVideos(eq(keywordText), anyInt());
-    }
-
-    @Test
-    @DisplayName("Youtube 검색 - API 호출 에러 발생")
-    void searchYoutube_apiError() {
-        /// given
-        Long keywordId1 = 1L;
-        String keywordText1 = "에러키워드";
-        Long keywordId2 = 2L;
-        String keywordText2 = "정상키워드";
-
-        List<KeywordMetricHourlyDto> topKeywords = Arrays.asList(
-                new KeywordMetricHourlyDto(keywordId1, keywordText1, Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 0, 0, false),
-                new KeywordMetricHourlyDto(keywordId2, keywordText2, Platform.GOOGLE_TREND,
-                        LocalDateTime.now(), 0, 0, false)
-        );
-        given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(topKeywords);
-
-        // 키워드1에 대해 API 호출 에러 발생 설정
-        given(videoApi.fetchVideos(eq(keywordText1), anyInt()))
-                .willReturn(Mono.error(
-                        new RetryableExternalApiException(503, "Youtube API Error")));
-
-        // 키워드2에 대해 정상 응답 설정
-        List<VideoDto> video2 = Arrays.asList(
-                VideoDto.builder().url("https://www.youtube.com/watch?v=v_id_k2").title("정상 영상 제목 k2")
-                        .publishedAt(LocalDateTime.now().minusDays(1))
-                        .thumbnailUrl("thumb_k2").description("desc_k2").build()
-        );
-        given(videoApi.fetchVideos(eq(keywordText2), anyInt())).willReturn(Mono.just(video2));
-
-        /// when
-        sourceService.searchYoutube();
-
-        /// then
-        // keywordMetricHourlyService.findHourlyMetrics() 호출 검증
-        then(keywordMetricHourlyService).should(times(1)).findHourlyMetrics();
-
-        // videoApi.fetchVideos()가 각 키워드에 대해 호출되었는지 검증
-        then(videoApi).should().fetchVideos(eq(keywordText1), anyInt());
-        then(videoApi).should().fetchVideos(eq(keywordText2), anyInt());
-
-        // 에러 발생한 키워드는 건너뛰고, 정상 키워드에 대한 데이터만 처리되었는지 검증
-        then(sourceRepository).should().insertIgnoreAll(argThat(sources -> {
-            assertThat(sources).hasSize(1);
-            assertThat(sources.getFirst().getFingerprint()).isEqualTo(video2.getFirst()
-                    .toEntity(Platform.YOUTUBE).getFingerprint());
-            return true;
-        }));
-
-        then(keywordSourceRepository).should().insertIgnoreAll(argThat(ksList -> {
-            assertThat(ksList).hasSize(1);
-            assertThat(ksList.getFirst().getKeyword().getId()).isEqualTo(keywordId2);
-            assertThat(ksList.getFirst().getSource().getFingerprint()).isEqualTo(
-                    video2.getFirst().toEntity(Platform.YOUTUBE).getFingerprint());
-            return true;
-        }));
-
-        // OpenGraphService는 정상 처리된 Source 개수만큼 호출 예상 (1개)
-        then(openGraphService).should(times(1)).enrichAsync(any(Source.class));
-    }
+	@InjectMocks
+	private SourceService sourceService;
+
+	@Mock
+	private PostService postService;
+	@Mock
+	private PostSourceRepository postSourceRepository;
+	@Mock
+	private SourceRepository sourceRepository;
+	@Mock
+	private NewsApiPort newsApi;
+	@Mock
+	private VideoApiPort videoApi;
+	@Mock
+	private KeywordMetricHourlyService keywordMetricHourlyService;
+	@Mock
+	private OpenGraphService openGraphService;
+	@Mock
+	private KeywordSourceRepository keywordSourceRepository;
+
+	private List<Source> newsSources;
+	private List<PostSource> newsPostSources;
+	private List<Source> youtubeSources;
+	private List<PostSource> youtubePostSources;
+	private Long postId = 1L;
+	private Post dummyPost;
+
+	@BeforeEach
+	void setUp() {
+		dummyPost = Post.builder().id(postId).build();
+		newsSources = Arrays.asList(
+			Source.builder().fingerprint("f1").normalizedUrl("https://news1").title("뉴스1").description("뉴스1 설명")
+				.thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+			Source.builder().fingerprint("f2").normalizedUrl("https://news2").title("뉴스2").description("뉴스2 설명")
+				.thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build(),
+			Source.builder().fingerprint("f3").normalizedUrl("https://news3").title("뉴스3").description("뉴스3 설명")
+				.thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.NAVER_NEWS).build()
+		);
+
+		newsPostSources = Arrays.asList(
+			PostSource.builder().id(101L).post(dummyPost).source(newsSources.get(0)).build(),
+			PostSource.builder().id(102L).post(dummyPost).source(newsSources.get(1)).build(),
+			PostSource.builder().id(103L).post(dummyPost).source(newsSources.get(2)).build()
+		);
+		youtubeSources = Arrays.asList(
+			Source.builder().fingerprint("f1").normalizedUrl("https://youtube1").title("유튜브1").description("유튜브1 설명")
+				.thumbnailUrl("thumb1").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+			Source.builder().fingerprint("f2").normalizedUrl("https://youtube2").title("유튜브2").description("유튜브2 설명")
+				.thumbnailUrl("thumb2").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build(),
+			Source.builder().fingerprint("f3").normalizedUrl("https://youtube3").title("유튜브3").description("유튜브3 설명")
+				.thumbnailUrl("thumb3").publishedAt(LocalDateTime.now()).platform(Platform.YOUTUBE).build()
+		);
+
+		youtubePostSources = Arrays.asList(
+			PostSource.builder().id(104L).post(dummyPost).source(youtubeSources.get(0)).build(),
+			PostSource.builder().id(105L).post(dummyPost).source(youtubeSources.get(1)).build(),
+			PostSource.builder().id(106L).post(dummyPost).source(youtubeSources.get(2)).build()
+		);
+	}
+
+	@Test
+	@DisplayName("뉴스 출처 10개 조회 - 성공")
+	void getTop10NewsSourcesByPostId_success() {
+		// given
+		Platform platform = Platform.NAVER_NEWS;
+		PageRequest pageRequest = PageRequest.of(0, 10);
+
+		given(postService.getPostById(eq(postId))).willReturn(dummyPost);
+		given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
+			.willReturn(newsPostSources);
+
+		// when
+		List<SourceDto> result = sourceService.getTop10NewsSourcesByPostId(postId);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).url()).isEqualTo("https://news1");
+		assertThat(result.get(1).title()).isEqualTo("뉴스2");
+	}
+
+	@Test
+	@DisplayName("뉴스 출처 10개 조회 - 데이터 없음")
+	void getTop10NewsSourcesByPostId_emptySourceList() {
+		// given
+		Platform platform = Platform.NAVER_NEWS;
+		PageRequest pageRequest = PageRequest.of(0, 10);
+
+		given(postService.getPostById(eq(postId))).willReturn(dummyPost);
+		given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
+			.willReturn(Collections.emptyList());
+
+		// when
+		List<SourceDto> result = sourceService.getTop10NewsSourcesByPostId(postId);
+
+		// then
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("뉴스 출처 10개 조회 - 포스트 없음")
+	void getTop10NewsSourcesByPostId_postNotFound() {
+		// given
+		Long postId = 999L;
+
+		given(postService.getPostById(postId))
+			.willThrow(new ServiceException("400", "해당 포스트를 찾을 수 없습니다."));
+
+		// when & then
+		assertThatThrownBy(() -> sourceService.getTop10NewsSourcesByPostId(postId))
+			.isInstanceOf(ServiceException.class)
+			.hasMessage("해당 포스트를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("영상 출처 10개 조회 - 성공")
+	void getTop10VideoSourcesByPostId_success() {
+		// given
+		Platform platform = Platform.YOUTUBE;
+		PageRequest pageRequest = PageRequest.of(0, 10);
+
+		given(postService.getPostById(eq(postId))).willReturn(dummyPost);
+		given(postSourceRepository.findAllWithSourceByPostIdAndPlatform(eq(postId), eq(platform), eq(pageRequest)))
+			.willReturn(youtubePostSources);
+
+		// when
+		List<SourceDto> result = sourceService.getTop10VideoSourcesByPostId(postId);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).url()).isEqualTo("https://youtube1");
+		assertThat(result.get(1).title()).isEqualTo("유튜브2");
+	}
+
+	@Test
+	@DisplayName("키워드 검색 소스 조회 - 성공")
+	void getTop10VideoSourcesByPostId_Success() {
+		PostDto post1 = new PostDto(1L, "키워드", "제목1", "설명1", "url1");
+		PostDto post2 = new PostDto(2L, "키워드", "제목2", "설명2", "url2");
+
+		List<PostDto> postDtos = List.of(post1, post2);
+
+		given(sourceRepository.findByPostIdsOrderByPublishedAtDesc(eq(List.of(1L, 2L)), any(PageRequest.class)))
+			.willReturn(newsSources);
+
+		// when
+		List<SourceDto> result = sourceService.getTop5SourcesByPosts(postDtos);
+
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).title()).isEqualTo("뉴스1");
+		assertThat(result.get(1).title()).isEqualTo("뉴스2");
+
+		verify(sourceRepository).findByPostIdsOrderByPublishedAtDesc(eq(List.of(1L, 2L)), any(PageRequest.class));
+	}
+
+	@Test
+	@DisplayName("키워드 검색 소스 조회 - 빈 데이터")
+	void getTop10VideoSourcesByPostId_Empty() {
+		// when
+		List<SourceDto> result = sourceService.getTop5SourcesByPosts(Collections.emptyList());
+
+		// then
+		assertThat(result).isEmpty();
+		verifyNoInteractions(sourceRepository);
+	}
+
+	@Test
+	@DisplayName("뉴스 검색 - 성공")
+	void searchNews_success() {
+		// given
+		Long keywordId = 1L;
+		String keywordText = "키워드";
+		KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId, keywordText, Platform.GOOGLE_TREND,
+			LocalDateTime.now(), 0, 0, false, null);
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(List.of(metric));
+
+		NewsDto dto = NewsDto.builder()
+			.title("뉴스 제목")
+			.link("https://example.com/news")
+			.originalLink("https://example.com/origin")
+			.description("뉴스 설명")
+			.pubDate(LocalDateTime.now())
+			.build();
+
+		given(newsApi.fetchNews(eq(keywordText), anyInt(), anyInt(), eq("sim")))
+			.willReturn(Mono.just(List.of(dto)));
+
+		// when
+		sourceService.searchNews();
+
+		// then
+		then(sourceRepository).should().insertIgnoreAll(argThat(sources ->
+			sources.size() == 1 &&
+				sources.getFirst().getTitle().equals("뉴스 제목")
+		));
+		then(keywordSourceRepository).should().insertIgnoreAll(argThat(ksList ->
+			ksList.size() == 1 &&
+				ksList.getFirst().getKeyword().getId().equals(keywordId)
+		));
+		then(openGraphService).should().enrichAsync(any(Source.class));
+	}
+
+	@Test
+	@DisplayName("뉴스 검색 - Empty 데이터")
+	void searchNews_empty() {
+		// given
+		KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(1L, "키워드",
+			Platform.NAVER_NEWS, LocalDateTime.now(), 0, 0, false, null);
+		given(keywordMetricHourlyService.findHourlyMetrics())
+			.willReturn(List.of(metric));
+
+		given(newsApi.fetchNews(anyString(), anyInt(), anyInt(), anyString()))
+			.willReturn(Mono.empty());
+
+		// when
+		sourceService.searchNews();
+
+		// then
+		then(sourceRepository).shouldHaveNoInteractions();
+		then(keywordSourceRepository).shouldHaveNoInteractions();
+		then(openGraphService).shouldHaveNoInteractions();
+	}
+
+	@Test
+	@DisplayName("뉴스 검색 - 에러 발생")
+	void searchNews_error() {
+		// given
+		KeywordMetricHourlyDto metric1 = new KeywordMetricHourlyDto(1L, "실패키워드",
+			Platform.NAVER_NEWS, LocalDateTime.now(), 0, 0, false, null);
+		KeywordMetricHourlyDto metric2 = new KeywordMetricHourlyDto(2L, "정상키워드",
+			Platform.NAVER_NEWS, LocalDateTime.now(), 0, 0, false, null);
+		given(keywordMetricHourlyService.findHourlyMetrics())
+			.willReturn(List.of(metric1, metric2));
+
+		NewsDto dto = NewsDto.builder()
+			.title("제목1")
+			.link("http://example.com/article")
+			.originalLink("http://example.com/original")
+			.description("설명")
+			.pubDate(LocalDateTime.of(2025, 4, 29, 12, 0))
+			.build();
+
+		given(newsApi.fetchNews(eq("실패키워드"), anyInt(), anyInt(), anyString()))
+			.willReturn(Mono.error(new RetryableExternalApiException(503, "서버 오류")));
+
+		given(newsApi.fetchNews(eq("정상키워드"), anyInt(), anyInt(), anyString()))
+			.willReturn(Mono.just(List.of(dto)));
+
+		// when
+		sourceService.searchNews();
+
+		// then
+		then(sourceRepository).should().insertIgnoreAll(argThat(sources -> {
+			assertThat(sources).hasSize(1);
+			assertThat(sources.getFirst().getTitle()).isEqualTo("제목1");
+			return true;
+		}));
+	}
+
+	@Test
+	@DisplayName("실시간 인기 유튜브 Source 조회 - 성공")
+	void getTopYoutubeSources_Success() {
+
+		/// given
+		// Mocking할 인기 키워드 목록 생성
+		List<KeywordMetricHourlyDto> mockTopKeywords = Arrays.asList(
+			new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 1000, 90, false, 1L),
+			new KeywordMetricHourlyDto(2L, "키워드 2", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 800, 70, false, 2L),
+			new KeywordMetricHourlyDto(3L, "키워드 3", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 300, 30, false, 3L),
+			new KeywordMetricHourlyDto(4L, "키워드 4", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 50, 77, false, 4L),
+			new KeywordMetricHourlyDto(5L, "키워드 5", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 650, 70, false, 5L),
+			new KeywordMetricHourlyDto(6L, "키워드 6", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 70, 86, false, 6L),
+			new KeywordMetricHourlyDto(7L, "키워드 7", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 120, 43, false, 7L),
+			new KeywordMetricHourlyDto(8L, "키워드 8", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 665, 86, false, 8L),
+			new KeywordMetricHourlyDto(9L, "키워드 9", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 505, 42, false, 9L),
+			new KeywordMetricHourlyDto(10L, "키워드 10", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 404, 55, false, 10L)
+		);
+
+		// Mocking할 Repository의 반환 값 (Page<TopSourceItemDto>) 생성
+		List<TopSourceItemDto> mockSourceItemDtoList = Arrays.asList(
+			TopSourceItemDto.builder()
+				.sourceId("source-id-1")
+				.url("http://youtube.com/v1")
+				.title("영상제목1")
+				.description(null)
+				.thumbnailUrl("thumb1")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(90)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-2")
+				.url("http://youtube.com/v2")
+				.title("영상제목2")
+				.description(null)
+				.thumbnailUrl("thumb2")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(70)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-3")
+				.url("http://youtube.com/v3")
+				.title("영상제목3")
+				.description(null)
+				.thumbnailUrl("thumb3")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(30)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-4")
+				.url("http://youtube.com/v4")
+				.title("영상제목4")
+				.description(null)
+				.thumbnailUrl("thumb4")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(77)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-5")
+				.url("http://youtube.com/v5")
+				.title("영상제목5")
+				.description(null)
+				.thumbnailUrl("thumb5")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(70)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-6")
+				.url("http://youtube.com/v6")
+				.title("영상제목6")
+				.description(null)
+				.thumbnailUrl("thumb6")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(86)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-7")
+				.url("http://youtube.com/v7")
+				.title("영상제목7")
+				.description(null)
+				.thumbnailUrl("thumb7")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(43)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-8")
+				.url("http://youtube.com/v8")
+				.title("영상제목8")
+				.description(null)
+				.thumbnailUrl("thumb8")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(86)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-9")
+				.url("http://youtube.com/v9")
+				.title("영상제목9")
+				.description(null)
+				.thumbnailUrl("thumb9")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(42)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-10")
+				.url("http://youtube.com/v10")
+				.title("영상제목10")
+				.description(null)
+				.thumbnailUrl("thumb10")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.YOUTUBE)
+				.score(55)
+				.build()
+		);
+
+		// Service 메소드에 전달될 Pageable 객체 (컨트롤러에서 넘어올 형태)
+		Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+		// Repository가 반환할 Mock Page<TopSourceItemDto> 객체 생성
+		Page<TopSourceItemDto> mockSourceItemDtoPage = new PageImpl<>(
+			mockSourceItemDtoList, pageable, mockSourceItemDtoList.size());
+
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 시 mockTopKeywords 반환
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+		//.findTopSourcesByPostIdsAndPlatformOrderedByScore()를 Mocking
+		given(postSourceRepository.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+			anyList(),
+			eq(Platform.YOUTUBE),
+			any(Pageable.class)
+		)).willReturn(mockSourceItemDtoPage);
+
+		/// when
+		// 테스트 대상 메소드 호출
+		Page<TopSourceItemDto> dto = sourceService.getTopSourcesByPlatform(pageable, Platform.YOUTUBE);
+		TopSourceListResponse result = TopSourceListResponse.from(dto);
+		/// then
+		assertThat(result).isNotNull();
+		assertThat(result.list()).isNotNull().hasSize(mockTopKeywords.size());
+		assertThat(result.meta()).isNotNull();
+
+		// list 안의 TopSourceItemDto 객체들이 올바르게 변환되었는지 검증
+		assertThat(result.list().getFirst().url())
+			.isEqualTo(mockSourceItemDtoList.getFirst().url());
+		assertThat(result.list().getFirst().title())
+			.isEqualTo(mockSourceItemDtoList.getFirst().title());
+		assertThat(result.list().getFirst().description()).isNull();
+		assertThat(result.list().getFirst().thumbnailUrl())
+			.isEqualTo(mockSourceItemDtoList.getFirst().thumbnailUrl());
+		assertThat(result.list().getFirst().publishedAt())
+			.isEqualTo(mockSourceItemDtoList.getFirst().publishedAt());
+		assertThat(result.list().getFirst().platform())
+			.isEqualTo(mockSourceItemDtoList.getFirst().platform());
+		assertThat(result.list().getFirst().score())
+			.isEqualTo(mockSourceItemDtoList.getFirst().score());
+
+		// Mock SourceList의 두 번째 항목도 검증
+		assertThat(result.list().get(1).url())
+			.isEqualTo(mockSourceItemDtoList.get(1).url());
+		assertThat(result.list().get(1).title())
+			.isEqualTo(mockSourceItemDtoList.get(1).title());
+		assertThat(result.list().get(1).description()).isNull();
+		assertThat(result.list().get(1).thumbnailUrl())
+			.isEqualTo(mockSourceItemDtoList.get(1).thumbnailUrl());
+		assertThat(result.list().get(1).publishedAt())
+			.isEqualTo(mockSourceItemDtoList.get(1).publishedAt());
+		assertThat(result.list().get(1).platform())
+			.isEqualTo(mockSourceItemDtoList.get(1).platform());
+
+		// meta 정보가 Mock Page에서 올바르게 변환되었는지 검증
+		assertThat(result.meta().page()).isEqualTo(mockSourceItemDtoPage.getNumber());
+		assertThat(result.meta().size()).isEqualTo(mockSourceItemDtoPage.getSize());
+		assertThat(result.meta().totalElements()).isEqualTo(mockSourceItemDtoPage.getTotalElements());
+		assertThat(result.meta().totalPages()).isEqualTo(mockSourceItemDtoPage.getTotalPages());
+		assertThat(result.meta().hasNext()).isEqualTo(mockSourceItemDtoPage.hasNext());
+		assertThat(result.meta().hasPrevious()).isEqualTo(mockSourceItemDtoPage.hasPrevious());
+
+		// Service 메소드가 의존하는 다른 메소드들을 올바르게 호출했는지 검증
+		verify(keywordMetricHourlyService, times(1))
+			.findHourlyMetrics();
+		verify(postSourceRepository, times(1))
+			.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+				anyList(),
+				eq(Platform.YOUTUBE),
+				any(Pageable.class)
+			);
+	}
+
+	@Test
+	@DisplayName("실시간 인기 유튜브 Source 조회 - 인기 키워드 목록이 비어있을 때")
+	void getTopYoutubeSources_EmptyKeywords() {
+
+		/// given
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 시 빈 리스트 반환하도록 Mocking
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(Collections.emptyList());
+
+		// Service 메소드에 전달될 Pageable 객체
+		Pageable pageable = PageRequest.of(0, 10, Sort.by("score").descending());
+
+		/// when
+		// 테스트 대상 메소드 호출
+		TopSourceListResponse result = TopSourceListResponse.from(
+			sourceService.getTopSourcesByPlatform(pageable, Platform.YOUTUBE));
+
+		/// then
+		assertThat(result).isNotNull();
+		assertThat(result.list()).isNotNull().isEmpty();
+
+		// Page.empty(pageable)이 생성하는 Page 객체의 메타 정보를 기준으로 검증
+		Page<TopSourceItemDto> emptyPage = Page.empty(pageable);
+
+		assertThat(result.meta()).isNotNull();
+		assertThat(result.meta().page()).isEqualTo(emptyPage.getNumber());
+		assertThat(result.meta().size()).isEqualTo(emptyPage.getSize());
+		assertThat(result.meta().totalElements()).isEqualTo(emptyPage.getTotalElements());
+		assertThat(result.meta().totalPages()).isEqualTo(emptyPage.getTotalPages());
+		assertThat(result.meta().hasNext()).isEqualTo(emptyPage.hasNext());
+		assertThat(result.meta().hasPrevious()).isEqualTo(emptyPage.hasPrevious());
+
+		// Service가 Repository 메소드를 호출하지 않았는지 검증
+		verify(postSourceRepository, never()).findTopSourcesByPostIdsAndPlatformOrderedByScore(
+			anyList(),
+			any(Platform.class),
+			any(Pageable.class)
+		);
+
+		// keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+		verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+	}
+
+	@Test
+	@DisplayName("실시간 인기 유튜브 Source 조회 - Repository가 빈 Page를 반환할 때")
+	void getTopYoutubeSources_RepositoryReturnsEmptyPage() {
+
+		/// given
+		// Mocking할 인기 키워드 목록 생성
+		List<KeywordMetricHourlyDto> mockTopKeywords = List.of(
+			new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 1000, 90, false, 1L)
+		);
+
+		// Mocking할 Repository의 반환 값 (빈 Page<TopSourceItemDto>) 생성
+		List<TopSourceItemDto> mockEmptySourceList = Collections.emptyList();
+		Pageable pageable = PageRequest.of(
+			0, 10);
+
+		// Repository가 반환할 Mock 빈 Page<TopSourceItemDto> 객체 생성
+		Page<TopSourceItemDto> mockEmptySourceItemDtoPage = new PageImpl<>(
+			mockEmptySourceList, pageable, 0);
+
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 시 비어있지 않은 목록 반환
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+		//.findTopSourcesByPostIdsAndPlatformOrderedByScore()를 Mocking
+		given(postSourceRepository.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+			anyList(),
+			eq(Platform.YOUTUBE),
+			eq(pageable)
+		)).willReturn(mockEmptySourceItemDtoPage);
+
+		/// when
+		// 테스트 대상 메소드 호출
+		TopSourceListResponse result = TopSourceListResponse.from(
+			sourceService.getTopSourcesByPlatform(pageable, Platform.YOUTUBE));
+
+		/// then
+		assertThat(result).isNotNull();
+		assertThat(result.list()).isNotNull().isEmpty();
+		assertThat(result.meta()).isNotNull();
+		assertThat(result.meta().page()).isEqualTo(mockEmptySourceItemDtoPage.getNumber());
+		assertThat(result.meta().size()).isEqualTo(mockEmptySourceItemDtoPage.getSize());
+		assertThat(result.meta().totalElements()).isEqualTo(mockEmptySourceItemDtoPage.getTotalElements());
+		assertThat(result.meta().totalPages()).isEqualTo(mockEmptySourceItemDtoPage.getTotalPages());
+		assertThat(result.meta().hasNext()).isEqualTo(mockEmptySourceItemDtoPage.hasNext());
+		assertThat(result.meta().hasPrevious()).isEqualTo(mockEmptySourceItemDtoPage.hasPrevious());
+
+		// Service가 Repository 메소드를 호출했는지 검증 (인기 키워드가 있으므로 호출되어야 함)
+		verify(postSourceRepository, times(1))
+			.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+				anyList(),
+				eq(Platform.YOUTUBE),
+				eq(pageable)
+			);
+
+		// keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+		verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+	}
+
+	@Test
+	@DisplayName("실시간 인기 네이버 뉴스 Source 조회 - 성공")
+	void getTopNaverNewsSources_Success() {
+
+		/// given
+		// Mocking할 인기 키워드 목록 생성
+		List<KeywordMetricHourlyDto> mockTopKeywords = Arrays.asList(
+			new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 1000, 90, false, 1L),
+			new KeywordMetricHourlyDto(2L, "키워드 2", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 800, 70, false, 2L),
+			new KeywordMetricHourlyDto(3L, "키워드 3", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 300, 30, false, 3L),
+			new KeywordMetricHourlyDto(4L, "키워드 4", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 50, 77, false, 4L),
+			new KeywordMetricHourlyDto(5L, "키워드 5", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 650, 70, false, 5L),
+			new KeywordMetricHourlyDto(6L, "키워드 6", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 70, 86, false, 6L),
+			new KeywordMetricHourlyDto(7L, "키워드 7", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 120, 43, false, 7L),
+			new KeywordMetricHourlyDto(8L, "키워드 8", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 665, 86, false, 8L),
+			new KeywordMetricHourlyDto(9L, "키워드 9", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 505, 42, false, 9L),
+			new KeywordMetricHourlyDto(10L, "키워드 10", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 404, 55, false, 10L)
+		);
+
+		// Mocking할 Repository의 반환 값 (Page<TopSourceItemDto>) 생성
+		List<TopSourceItemDto> mockSourceItemDtoList = Arrays.asList(
+			TopSourceItemDto.builder()
+				.sourceId("source-id-1")
+				.url("http://news.naver.com/article/1")
+				.title("뉴스제목1")
+				.description("네이버 뉴스 요약 1")
+				.thumbnailUrl("thumb1")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(90)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-2")
+				.url("http://news.naver.com/article/2")
+				.title("뉴스제목2")
+				.description("네이버 뉴스 요약 2")
+				.thumbnailUrl("thumb2")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(70)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-3")
+				.url("http://news.naver.com/article/3")
+				.title("뉴스제목3")
+				.description("네이버 뉴스 요약 3")
+				.thumbnailUrl("thumb3")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(30)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-4")
+				.url("http://news.naver.com/article/4")
+				.title("뉴스제목4")
+				.description("네이버 뉴스 요약 4")
+				.thumbnailUrl("thumb4")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(77)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-5")
+				.url("http://news.naver.com/article/5")
+				.title("뉴스제목5")
+				.description("네이버 뉴스 요약 5")
+				.thumbnailUrl("thumb5")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(70)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-6")
+				.url("http://news.naver.com/article/6")
+				.title("뉴스제목6")
+				.description("네이버 뉴스 요약 6")
+				.thumbnailUrl("thumb6")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(86)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-7")
+				.url("http://news.naver.com/article/7")
+				.title("뉴스제목7")
+				.description("네이버 뉴스 요약 7")
+				.thumbnailUrl("thumb7")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(43)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-8")
+				.url("http://news.naver.com/article/8")
+				.title("뉴스제목8")
+				.description("네이버 뉴스 요약 8")
+				.thumbnailUrl("thumb8")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(86)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-9")
+				.url("http://news.naver.com/article/9")
+				.title("뉴스제목9")
+				.description("네이버 뉴스 요약 9")
+				.thumbnailUrl("thumb9")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(42)
+				.build(),
+			TopSourceItemDto.builder()
+				.sourceId("source-id-10")
+				.url("http://news.naver.com/article/10")
+				.title("뉴스제목10")
+				.description("네이버 뉴스 요약 10")
+				.thumbnailUrl("thumb10")
+				.publishedAt(LocalDateTime.now())
+				.platform(Platform.NAVER_NEWS)
+				.score(55)
+				.build()
+		);
+
+		// Service 메소드에 전달될 Pageable 객체 (컨트롤러에서 넘어올 형태)
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// Repository가 반환할 Mock Page<TopSourceItemDto> 객체 생성
+		Page<TopSourceItemDto> mockSourceItemDtoPage = new PageImpl<>(
+			mockSourceItemDtoList, pageable, mockSourceItemDtoList.size());
+
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 시 mockTopKeywords 반환
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+		//.findTopSourcesByPostIdsAndPlatformOrderedByScore()를 Mocking
+		given(postSourceRepository.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+			anyList(),
+			eq(Platform.NAVER_NEWS),
+			eq(pageable)
+		)).willReturn(mockSourceItemDtoPage);
+
+		/// when
+		// 테스트 대상 메소드 호출
+		TopSourceListResponse result = TopSourceListResponse.from(
+			sourceService.getTopSourcesByPlatform(pageable, Platform.NAVER_NEWS));
+
+		/// then
+		assertThat(result).isNotNull();
+		assertThat(result.list()).isNotNull().hasSize(mockTopKeywords.size());
+		assertThat(result.meta()).isNotNull();
+
+		// list 안의 TopSourceItemDto 객체들이 올바르게 변환되었는지 검증
+		assertThat(result.list().getFirst().url())
+			.isEqualTo(mockSourceItemDtoList.getFirst().url());
+		assertThat(result.list().getFirst().title())
+			.isEqualTo(mockSourceItemDtoList.getFirst().title());
+		assertThat(result.list().getFirst().description())
+			.isEqualTo(mockSourceItemDtoList.getFirst().description());
+		assertThat(result.list().getFirst().thumbnailUrl())
+			.isEqualTo(mockSourceItemDtoList.getFirst().thumbnailUrl());
+		assertThat(result.list().getFirst().publishedAt())
+			.isEqualTo(mockSourceItemDtoList.getFirst().publishedAt());
+		assertThat(result.list().getFirst().platform())
+			.isEqualTo(mockSourceItemDtoList.getFirst().platform());
+		assertThat(result.list().getFirst().score())
+			.isEqualTo(mockSourceItemDtoList.getFirst().score());
+
+		// Mock SourceList의 두 번째 항목도 검증
+		assertThat(result.list().get(1).url())
+			.isEqualTo(mockSourceItemDtoList.get(1).url());
+		assertThat(result.list().get(1).title())
+			.isEqualTo(mockSourceItemDtoList.get(1).title());
+		assertThat(result.list().get(1).description())
+			.isEqualTo(mockSourceItemDtoList.get(1).description());
+		assertThat(result.list().get(1).thumbnailUrl())
+			.isEqualTo(mockSourceItemDtoList.get(1).thumbnailUrl());
+		assertThat(result.list().get(1).publishedAt())
+			.isEqualTo(mockSourceItemDtoList.get(1).publishedAt());
+		assertThat(result.list().get(1).platform())
+			.isEqualTo(mockSourceItemDtoList.get(1).platform());
+		assertThat(result.list().get(1).score())
+			.isEqualTo(mockSourceItemDtoList.get(1).score());
+
+		// meta 정보가 Mock Page에서 올바르게 변환되었는지 검증
+		assertThat(result.meta().page()).isEqualTo(mockSourceItemDtoPage.getNumber());
+		assertThat(result.meta().size()).isEqualTo(mockSourceItemDtoPage.getSize());
+		assertThat(result.meta().totalElements()).isEqualTo(mockSourceItemDtoPage.getTotalElements());
+		assertThat(result.meta().totalPages()).isEqualTo(mockSourceItemDtoPage.getTotalPages());
+		assertThat(result.meta().hasNext()).isEqualTo(mockSourceItemDtoPage.hasNext());
+		assertThat(result.meta().hasPrevious()).isEqualTo(mockSourceItemDtoPage.hasPrevious());
+
+		// Service 메소드가 의존하는 다른 메소드들을 올바르게 호출했는지 검증
+		verify(keywordMetricHourlyService, times(1))
+			.findHourlyMetrics();
+		verify(postSourceRepository, times(1))
+			.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+				anyList(),
+				eq(Platform.NAVER_NEWS),
+				eq(pageable)
+			);
+	}
+
+	@Test
+	@DisplayName("실시간 인기 네이버 뉴스 Source 조회 - 인기 키워드 목록이 비어있을 때")
+	void getTopNaverNewsSources_EmptyKeywords() {
+
+		/// given
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 시 빈 리스트 반환하도록 Mocking
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(Collections.emptyList());
+
+		// Service 메소드에 전달될 Pageable 객체
+		Pageable pageable = PageRequest.of(0, 10);
+
+		/// when
+		// 테스트 대상 메소드 호출
+		TopSourceListResponse result = TopSourceListResponse.from(
+			sourceService.getTopSourcesByPlatform(pageable, Platform.NAVER_NEWS));
+
+		/// then
+		assertThat(result).isNotNull();
+		assertThat(result.list()).isNotNull().isEmpty();
+
+		// Page.empty(pageable)이 생성하는 Page 객체의 메타 정보를 기준으로 검증
+		Page<TopSourceItemDto> emptyPage = Page.empty(pageable);
+
+		assertThat(result.meta()).isNotNull();
+		assertThat(result.meta().page()).isEqualTo(emptyPage.getNumber());
+		assertThat(result.meta().size()).isEqualTo(emptyPage.getSize());
+		assertThat(result.meta().totalElements()).isEqualTo(emptyPage.getTotalElements());
+		assertThat(result.meta().totalPages()).isEqualTo(emptyPage.getTotalPages());
+		assertThat(result.meta().hasNext()).isEqualTo(emptyPage.hasNext());
+		assertThat(result.meta().hasPrevious()).isEqualTo(emptyPage.hasPrevious());
+
+		// Service가 Repository 메소드를 호출하지 않았는지 검증
+		verify(postSourceRepository, never()).findTopSourcesByPostIdsAndPlatformOrderedByScore(
+			anyList(),
+			any(Platform.class),
+			any(Pageable.class)
+		);
+
+		// keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+		verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+	}
+
+	@Test
+	@DisplayName("실시간 인기 네이버 뉴스 Source 조회 - Repository가 빈 Page를 반환할 때")
+	void getTopNaverNewsSources_RepositoryReturnsEmptyPage() {
+
+		/// given
+		// Mocking할 인기 키워드 목록 생성
+		List<KeywordMetricHourlyDto> mockTopKeywords = List.of(
+			new KeywordMetricHourlyDto(1L, "키워드 1", Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 1000, 90, false, 1L)
+		);
+
+		// Mocking할 Repository의 반환 값 (빈 Page<TopSourceItemDto>) 생성
+		List<TopSourceItemDto> mockEmptySourceItemDtoList = Collections.emptyList();
+		Pageable pageable = PageRequest.of(
+			0, 10);
+
+		// Repository가 반환할 Mock 빈 Page<Source> 객체 생성 (내용은 비어있고, 전체 개수는 0)
+		Page<TopSourceItemDto> mockEmptySourceItemDtoPage = new PageImpl<>(
+			mockEmptySourceItemDtoList, pageable, 0);
+
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 시 비어있지 않은 목록 반환
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(mockTopKeywords);
+
+		//.findTopSourcesByPostIdsAndPlatformOrderedByScore()를 Mocking
+		given(postSourceRepository.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+			anyList(),
+			eq(Platform.NAVER_NEWS),
+			eq(pageable)
+		)).willReturn(mockEmptySourceItemDtoPage);
+
+		/// when
+		// 테스트 대상 메소드 호출
+		TopSourceListResponse result = TopSourceListResponse.from(
+			sourceService.getTopSourcesByPlatform(pageable, Platform.NAVER_NEWS));
+
+		/// then
+		assertThat(result).isNotNull();
+		assertThat(result.list()).isNotNull().isEmpty();
+		assertThat(result.meta()).isNotNull();
+		assertThat(result.meta().page()).isEqualTo(mockEmptySourceItemDtoPage.getNumber());
+		assertThat(result.meta().size()).isEqualTo(mockEmptySourceItemDtoPage.getSize());
+		assertThat(result.meta().totalElements()).isEqualTo(mockEmptySourceItemDtoPage.getTotalElements());
+		assertThat(result.meta().totalPages()).isEqualTo(mockEmptySourceItemDtoPage.getTotalPages());
+		assertThat(result.meta().hasNext()).isEqualTo(mockEmptySourceItemDtoPage.hasNext());
+		assertThat(result.meta().hasPrevious()).isEqualTo(mockEmptySourceItemDtoPage.hasPrevious());
+
+		// Service가 Repository 메소드를 호출했는지 검증 (인기 키워드가 있으므로 호출되어야 함)
+		verify(postSourceRepository, times(1))
+			.findTopSourcesByPostIdsAndPlatformOrderedByScore(
+				anyList(),
+				eq(Platform.NAVER_NEWS),
+				eq(pageable)
+			);
+
+		// keywordMetricHourlyService.findHourlyMetrics()는 1번 호출되었는지 검증
+		verify(keywordMetricHourlyService, times(1)).findHourlyMetrics();
+	}
+
+	@Test
+	@DisplayName("Youtube 검색 - 성공")
+	void searchYoutube_success() {
+		/// given
+		Long keywordId1 = 1L;
+		String keywordText1 = "키워드1";
+		Long keywordId2 = 2L;
+		String keywordText2 = "키워드2";
+
+		// Mock: keywordMetricHourlyService.findHourlyMetrics()가 키워드 목록을 반환하도록 설정
+		List<KeywordMetricHourlyDto> topKeywords = Arrays.asList(
+			new KeywordMetricHourlyDto(keywordId1, keywordText1, Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 0, 0, false, null),
+			new KeywordMetricHourlyDto(keywordId2, keywordText2, Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 0, 0, false, null)
+		);
+
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(topKeywords);
+
+		// videoApi.fetchVideos()가 각 키워드에 대해 VideoDto 목록을 담은 Mono를 반환하도록 설정
+		// 키워드1에 대한 응답
+		List<VideoDto> video1 = Arrays.asList(
+			VideoDto.builder().url("https://www.youtube.com/watch?v=v1_id_k1").title("영상1 제목 k1").publishedAt(
+					LocalDateTime.now().minusDays(1)).thumbnailUrl("thumb1_k1")
+				.description("desc1_k1").build(),
+			VideoDto.builder().url("https://www.youtube.com/watch?v=v2_id_k1").title("영상2 제목 k1").publishedAt(
+					LocalDateTime.now().minusDays(2)).thumbnailUrl("thumb2_k1")
+				.description("desc2_k1").build()
+		);
+
+		given(videoApi.fetchVideos(eq(keywordText1), anyInt()))
+			.willReturn(Mono.just(video1));
+
+		// 키워드2에 대한 응답 (일부러 중복되는 영상 포함)
+		List<VideoDto> video2 = Arrays.asList(
+			VideoDto.builder().url("https://www.youtube.com/watch?v=v3_id_k2").title("영상3 제목 k2").publishedAt(
+					LocalDateTime.now().minusDays(3)).thumbnailUrl("thumb3_k2")
+				.description("desc3_k2").build(),
+			// 중복 영상
+			VideoDto.builder().url("https://www.youtube.com/watch?v=v2_id_k1").title("영상2 제목 k1").publishedAt(
+					LocalDateTime.now().minusDays(2)).thumbnailUrl("thumb2_k1")
+				.description("desc2_k1").build()
+		);
+
+		given(videoApi.fetchVideos(eq(keywordText2), anyInt()))
+			.willReturn(Mono.just(video2));
+
+		// 예상되는 중복 제거된 VideoDto 목록
+		List<VideoDto> expectedDistinctVideoDtos = Arrays.asList(
+			video1.get(0),
+			video1.get(1),
+			video2.get(0)
+		);
+
+		/// when
+		// searchYoutube 메소드 실행
+		sourceService.searchYoutube();
+
+		/// then
+		// 1. videoApi.fetchVideos가 각 키워드에 대해 호출되었는지 검증
+		then(videoApi).should().fetchVideos(eq(keywordText1), anyInt());
+		then(videoApi).should().fetchVideos(eq(keywordText2), anyInt());
+
+		// 2. sourceRepository.insertIgnoreAll 호출 검증
+		// argThat을 사용하여 전달된 리스트의 크기와 내용 검증
+		then(sourceRepository).should().insertIgnoreAll(argThat(sources -> {
+
+			// 저장되는 Source 리스트의 크기 검증
+			assertThat(sources).hasSize(expectedDistinctVideoDtos.size());
+
+			// 저장되는 각 Source 엔티티의 필드 검증
+			assertThat(sources).allSatisfy(source -> {
+				// Service가 VideoDto.toEntity를 호출하여 Source를 만들 때 description이 잘 담기는지 여기서 확인
+				assertThat(source.getDescription()).isNotNull().isNotEmpty();
+
+				// fingerprint 검증: Service 로직대로 fingerprint는 URL 해시이며 null이 아니어야 함
+				assertThat(source.getFingerprint()).isNotNull().isNotEmpty();
+
+				// normalizedUrl 검증: Service 로직대로 normalizedUrl는 VideoDto.id로 구성되며 null이 아니어야 함
+				assertThat(source.getNormalizedUrl()).isNotNull().isNotEmpty();
+
+				assertThat(source.getTitle()).isNotNull().isNotEmpty();
+				assertThat(source.getPublishedAt()).isNotNull();
+				assertThat(source.getPlatform()).isEqualTo(Platform.YOUTUBE);
+			});
+
+			// 저장되는 Source 엔티티들의 fingerprint 집합이 예상되는 distinct Source fingerprint 집합과 일치하는지 확인
+			// 예상되는 fingerprint는 테스트 코드에서 Mock VideoDto.toEntity().getFingerprint()를 호출하여 계산
+			List<String> savedSourceFingerprints = sources.stream()
+				.map(Source::getFingerprint).toList();
+			List<String> expectedDistinctFingerprints = expectedDistinctVideoDtos.stream()
+				.map(dto -> dto.toEntity(Platform.YOUTUBE).getFingerprint())
+				.toList();
+
+			assertThat(savedSourceFingerprints).containsExactlyInAnyOrderElementsOf(expectedDistinctFingerprints);
+
+			return true;
+		}));
+
+		// 3. keywordSourceRepository.insertIgnoreAll 호출 검증
+		then(keywordSourceRepository).should().insertIgnoreAll(argThat(ksList -> {
+			assertThat(ksList).hasSize(4);
+
+			// 리스트에 특정 Keyword ID와 Source fingerprint 조합을 가진 KeywordSource가 포함되어 있는지 확인
+			List<String> ksCominations = ksList.stream()
+				.map(ks -> ks.getKeyword().getId() + "-" +
+					ks.getSource().getFingerprint())
+				.toList();
+			assertThat(ksCominations).containsExactlyInAnyOrder(
+				keywordId1 + "-" + video1.get(0).toEntity(Platform.YOUTUBE).getFingerprint(),
+				keywordId1 + "-" + video1.get(1).toEntity(Platform.YOUTUBE).getFingerprint(),
+				keywordId2 + "-" + video2.get(0).toEntity(Platform.YOUTUBE).getFingerprint(),
+				keywordId2 + "-" + video2.get(1).toEntity(Platform.YOUTUBE).getFingerprint()
+			);
+			return true;
+		}));
+
+		// 4. openGraphService.enrichAsync 호출 검증
+		// distinctSources 리스트의 각 Source에 대해 호출되었는지 검증
+		then(openGraphService).should(times(3))
+			.enrichAsync(any(Source.class));
+	}
+
+	@Test
+	@DisplayName("Youtube 검색 - API 응답 비어있음")
+	void searchYoutube_emptyApiResponse() {
+		/// given
+		Long keywordId1 = 1L;
+		String keywordText = "빈응답키워드";
+		KeywordMetricHourlyDto metric = new KeywordMetricHourlyDto(keywordId1, keywordText,
+			Platform.GOOGLE_TREND, LocalDateTime.now(), 0, 0, false, null);
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(List.of(metric));
+
+		// videoApi.fetchVideos()가 빈 목록을 담은 Mono를 반환하도록 설정
+		given(videoApi.fetchVideos(eq(keywordText), anyInt())).willReturn(Mono.just(List.of()));
+
+		/// when
+		sourceService.searchYoutube();
+
+		/// then
+		// insertIgnoreAll 메소드들이 호출되지 않았는지 검증
+		then(sourceRepository).shouldHaveNoInteractions();
+		then(keywordSourceRepository).shouldHaveNoInteractions();
+		// API 응답 비어있으면 OpenGraph도 호출 안됨
+		then(openGraphService).shouldHaveNoInteractions();
+
+		// keywordMetricHourlyService.findHourlyMetrics()는 호출되었는지 검증
+		then(keywordMetricHourlyService).should(times(1)).findHourlyMetrics();
+		// videoApi.fetchVideos()도 호출되었는지 검증
+		then(videoApi).should(times(1)).fetchVideos(eq(keywordText), anyInt());
+	}
+
+	@Test
+	@DisplayName("Youtube 검색 - API 호출 에러 발생")
+	void searchYoutube_apiError() {
+		/// given
+		Long keywordId1 = 1L;
+		String keywordText1 = "에러키워드";
+		Long keywordId2 = 2L;
+		String keywordText2 = "정상키워드";
+
+		List<KeywordMetricHourlyDto> topKeywords = Arrays.asList(
+			new KeywordMetricHourlyDto(keywordId1, keywordText1, Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 0, 0, false, null),
+			new KeywordMetricHourlyDto(keywordId2, keywordText2, Platform.GOOGLE_TREND,
+				LocalDateTime.now(), 0, 0, false, null)
+		);
+		given(keywordMetricHourlyService.findHourlyMetrics()).willReturn(topKeywords);
+
+		// 키워드1에 대해 API 호출 에러 발생 설정
+		given(videoApi.fetchVideos(eq(keywordText1), anyInt()))
+			.willReturn(Mono.error(
+				new RetryableExternalApiException(503, "Youtube API Error")));
+
+		// 키워드2에 대해 정상 응답 설정
+		List<VideoDto> video2 = Arrays.asList(
+			VideoDto.builder().url("https://www.youtube.com/watch?v=v_id_k2").title("정상 영상 제목 k2")
+				.publishedAt(LocalDateTime.now().minusDays(1))
+				.thumbnailUrl("thumb_k2").description("desc_k2").build()
+		);
+		given(videoApi.fetchVideos(eq(keywordText2), anyInt())).willReturn(Mono.just(video2));
+
+		/// when
+		sourceService.searchYoutube();
+
+		/// then
+		// keywordMetricHourlyService.findHourlyMetrics() 호출 검증
+		then(keywordMetricHourlyService).should(times(1)).findHourlyMetrics();
+
+		// videoApi.fetchVideos()가 각 키워드에 대해 호출되었는지 검증
+		then(videoApi).should().fetchVideos(eq(keywordText1), anyInt());
+		then(videoApi).should().fetchVideos(eq(keywordText2), anyInt());
+
+		// 에러 발생한 키워드는 건너뛰고, 정상 키워드에 대한 데이터만 처리되었는지 검증
+		then(sourceRepository).should().insertIgnoreAll(argThat(sources -> {
+			assertThat(sources).hasSize(1);
+			assertThat(sources.getFirst().getFingerprint()).isEqualTo(video2.getFirst()
+				.toEntity(Platform.YOUTUBE).getFingerprint());
+			return true;
+		}));
+
+		then(keywordSourceRepository).should().insertIgnoreAll(argThat(ksList -> {
+			assertThat(ksList).hasSize(1);
+			assertThat(ksList.getFirst().getKeyword().getId()).isEqualTo(keywordId2);
+			assertThat(ksList.getFirst().getSource().getFingerprint()).isEqualTo(
+				video2.getFirst().toEntity(Platform.YOUTUBE).getFingerprint());
+			return true;
+		}));
+
+		// OpenGraphService는 정상 처리된 Source 개수만큼 호출 예상 (1개)
+		then(openGraphService).should(times(1)).enrichAsync(any(Source.class));
+	}
 }


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #160 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. News API에서 제대로 못 불러오는 문제 해결 -> BaseURL을 WebClient Config에 설정
2. videos/hot GET API 데이터 못 불러오는 문제 해결 
  - 관련 JPA Query 수정(findTopSourcesByPostIdsAndPlatformOrderedByScore) -> Group By로 Distinct 해결
  - 연관된 news/hot과 로직이 같으므로 하나의 service method로 통합

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #160