### PR TITLE
Bug/187 get post top revision

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/admin/controller/BatchJobControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/admin/controller/BatchJobControllerV1.java
@@ -33,7 +33,7 @@ public class BatchJobControllerV1 {
 	public ResponseEntity<String> runTrendToPostJob() {
 		try {
 			// 요청 시점 (현재 시각)
-			LocalDateTime bucketAt = LocalDateTime.now(ZoneId.of("Asia/Seoul")).withSecond(0).withNano(0);
+			LocalDateTime bucketAt = LocalDateTime.now(ZoneId.of("UTC")).withSecond(0).withNano(0);
 
 			// JobParameters는 항상 고유해야 실행됨
 			JobParameters params = new JobParametersBuilder()

--- a/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordMetricHourlyRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/keyword/repository/KeywordMetricHourlyRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import site.kkokkio.domain.keyword.entity.KeywordMetricHourly;
@@ -24,7 +25,5 @@ public interface KeywordMetricHourlyRepository extends JpaRepository<KeywordMetr
 		LIMIT 10
 		""",
 		nativeQuery = true)
-	List<KeywordMetricHourly> findTop10HourlyMetricsClosestToNowNative(LocalDateTime now);
-
-	List<KeywordMetricHourly> findTop10ById_BucketAtOrderByScoreDesc(LocalDateTime bucketAt);
+	List<KeywordMetricHourly> findTop10HourlyMetricsClosestToNowNative(@Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/site/kkokkio/domain/post/controller/PostControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/controller/PostControllerV1.java
@@ -43,7 +43,7 @@ public class PostControllerV1 {
 	@Operation(summary = "포스트 조회")
 	@ApiErrorCodeExamples({ErrorCode.POST_NOT_FOUND_2})
 	@GetMapping("/{postId}")
-	public RsData<PostDetailResponse> getPostById(@PathVariable Long postId) {
+	public RsData<PostDetailResponse> getPostById(@PathVariable("postId") Long postId) {
 		PostDto postDto = postService.getPostWithKeywordById(postId);
 		PostDetailResponse data = PostDetailResponse.builder()
 			.postId(postDto.postId())
@@ -110,14 +110,14 @@ public class PostControllerV1 {
 			defaultPageable.getPageSize(),
 			sort
 		);
-	    	Page<PostDto> postDtoList = keywordService.getPostListByKeyword(keyword, customPaging);
-	    	List<SourceDto> searchSourceList = sourceService.getTop5SourcesByPosts(postDtoList.toList());
-	    	PostSearchSourceListResponse response = PostSearchSourceListResponse.from(searchSourceList, postDtoList);
-	    	return new RsData<>(
-	      		"200",
-	      		"성공적으로 조회되었습니다.",
-	      		response
-	    	);
+		Page<PostDto> postDtoList = keywordService.getPostListByKeyword(keyword, customPaging);
+		List<SourceDto> searchSourceList = sourceService.getTop5SourcesByPosts(postDtoList.toList());
+		PostSearchSourceListResponse response = PostSearchSourceListResponse.from(searchSourceList, postDtoList);
+		return new RsData<>(
+			"200",
+			"성공적으로 조회되었습니다.",
+			response
+		);
 	}
 
 	@Operation(summary = "실시간 키워드에 해당하는 포스트 리스트 조회")

--- a/backend/src/main/java/site/kkokkio/domain/post/service/PostService.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/service/PostService.java
@@ -74,15 +74,10 @@ public class PostService {
 
 	@Transactional(readOnly = true)
 	public List<PostDto> getTopPostsWithKeyword() throws IOException {
-		// 기존 로직 (DB 조회) 실행
-		LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
-			.withMinute(0)
-			.withSecond(0)
-			.withNano(0);
-
-		//최신 버킷 기준으로 점수 높은 순 키워드(10개)
-		List<KeywordMetricHourly> topKeywordMetrics = keywordMetricHourlyRepository.findTop10ById_BucketAtOrderByScoreDesc(
-			now);
+		LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+		List<KeywordMetricHourly> topKeywordMetrics = keywordMetricHourlyRepository.findTop10HourlyMetricsClosestToNowNative(
+			now
+		);
 
 		return topKeywordMetrics.stream()
 			.peek(metric -> {

--- a/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
+++ b/backend/src/main/java/site/kkokkio/global/init/BaseInitData.java
@@ -108,7 +108,7 @@ public class BaseInitData implements CommandLineRunner {
 		JobInstanceAlreadyCompleteException,
 		JobParametersInvalidException {
 
-		LocalDateTime bucketAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+		LocalDateTime bucketAt = LocalDateTime.now(ZoneId.of("UTC"))
 			.withSecond(0).withNano(0);
 		JobParameters params = new JobParametersBuilder()
 			.addString("runTime", bucketAt.toString())

--- a/backend/src/main/java/site/kkokkio/global/scheduler/HourScheduler.java
+++ b/backend/src/main/java/site/kkokkio/global/scheduler/HourScheduler.java
@@ -28,7 +28,7 @@ public class HourScheduler {
 	public void runTrendingKeywordsJob() throws
 		JobExecutionAlreadyRunningException,
 		JobRestartException, JobInstanceAlreadyCompleteException, JobParametersInvalidException {
-		LocalDateTime bucketAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+		LocalDateTime bucketAt = LocalDateTime.now(ZoneId.of("UTC"))
 			.withSecond(0).withNano(0); // bucketAt 매시 정각 설정
 		JobParameters jobParameters = new JobParametersBuilder()
 			.addString("runTime", bucketAt.toString())

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -56,7 +56,7 @@ spring:
   jackson:
     serialization:
       FAIL_ON_EMPTY_BEANS: false # 빈 객체도 직렬화가 가능하도록 설정 (Empty)
-    time-zone: Asia/Seoul
+    time-zone: UTC
 
   mail:
     host: smtp.gmail.com # SMTP 서버 호스트 (Gmail)

--- a/backend/src/test/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/keyword/service/KeywordMetricHourlyServiceTest.java
@@ -44,7 +44,7 @@ public class KeywordMetricHourlyServiceTest {
 			Keyword keyword = Keyword.builder().id((long) i).text("키워드 " + i).build();
 			KeywordMetricHourlyId id = KeywordMetricHourlyId.builder()
 				.keywordId((long) i)
-				.bucketAt(LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusHours(i))
+				.bucketAt(LocalDateTime.now(ZoneId.of("UTC")).minusHours(i))
 				.platform(Platform.GOOGLE_TREND)
 				.build();
 			KeywordMetricHourly metric = KeywordMetricHourly.builder()

--- a/backend/src/test/java/site/kkokkio/domain/post/service/PostServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/post/service/PostServiceTest.java
@@ -134,7 +134,7 @@ public class PostServiceTest {
 			.post(post)
 			.build();
 
-		given(keywordMetricHourlyRepository.findTop10ById_BucketAtOrderByScoreDesc(any())).willReturn(List.of(metric));
+		given(keywordMetricHourlyRepository.findTop10HourlyMetricsClosestToNowNative(any())).willReturn(List.of(metric));
 
 		// when
 		List<PostDto> result = postService.getTopPostsWithKeyword();
@@ -148,7 +148,7 @@ public class PostServiceTest {
 	@DisplayName("top10 키워드 포스트 조회 - 포스트 없음")
 	void test4() throws IOException {
 		// given
-		given(keywordMetricHourlyRepository.findTop10ById_BucketAtOrderByScoreDesc(any()))
+		given(keywordMetricHourlyRepository.findTop10HourlyMetricsClosestToNowNative(any()))
 			.willReturn(Collections.emptyList());
 
 		// when


### PR DESCRIPTION
## 연관된 이슈

> [#187](https://github.com/prgrms-web-devcourse-final-project/WEB4_5_GAEPPADAK_BE/issues/187)


## 작업 내용

> 실시간 포스트 조회(GET /posts/top) 오류 해결
> 코드 내의 시간을 utc로 변경


## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 아침에 설명 드린 이유로 쿼리를 새로 짜서 만들었으나 이후 pr을 위해 다시 체크하는 중 이전에 연결해 테스트했으나 작동하지 않았다고 인식하고 있던 findTop10HourlyMetricsClosestToNowNative으로 posts/top이 되는걸 확인해서 수정한 쿼리를 지우고 이걸로 연결했습니다.
> findTop10HourlyMetricsClosestToNowNative에서 @Param("now")이 없어 서버가 꺼져 추가했습니다.

closes #187