### PR TITLE
feat: 회원정보 수정 api 추가

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
@@ -1,5 +1,6 @@
 package site.kkokkio.domain.member.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,16 +13,21 @@ import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import site.kkokkio.domain.member.controller.dto.EmailVerificationRequest;
 import site.kkokkio.domain.member.controller.dto.MemberLoginRequest;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
+import site.kkokkio.domain.member.controller.dto.PasswordVerificationRequest;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
 import site.kkokkio.global.dto.RsData;
 import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
 import site.kkokkio.global.exception.doc.ErrorCode;
+import site.kkokkio.global.security.CustomUserDetails;
 import site.kkokkio.global.util.JwtUtils;
 
 @Tag(name = "Auth API", description = "인증 관련 기능을 제공")
@@ -90,5 +96,17 @@ public class AuthControllerV1 {
 		return isSuccess
 			? new RsData<>("200", "이메일 인증에 성공하였습니다.")
 			: new RsData<>("400", "이메일 인증에 실패하였습니다.");
+	}
+
+	@Operation(summary = "비밀번호 인증")
+	@PostMapping("/check-password")
+	public RsData<Void> validatePassword(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid PasswordVerificationRequest passwordCheckRequest
+	) {
+		boolean isSuccess = authService.checkPassword(passwordCheckRequest, userDetails);
+		return isSuccess
+			? new RsData<>("200", "비밀번호 인증에 성공하였습니다.")
+			: new RsData<>("400", "비밀번호 인증에 실패하였습니다.");
 	}
 }

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -1,5 +1,6 @@
 package site.kkokkio.domain.member.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,6 +23,7 @@ import site.kkokkio.domain.member.service.MemberService;
 import site.kkokkio.global.dto.RsData;
 import site.kkokkio.global.exception.doc.ApiErrorCodeExamples;
 import site.kkokkio.global.exception.doc.ErrorCode;
+import site.kkokkio.global.security.CustomUserDetails;
 import site.kkokkio.global.util.JwtUtils;
 
 @Tag(name = "Member API", description = "회원 관련 기능을 제공")
@@ -64,8 +66,11 @@ public class MemberControllerV1 {
 	@ApiErrorCodeExamples({ErrorCode.MISSING_TOKEN, ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
 		ErrorCode.UNSUPPORTED_TOKEN, ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH})
 	@PatchMapping("/me")
-	public RsData<MemberResponse> modifyMember(HttpServletRequest request, @RequestBody @Valid MemberUpdateRequest requestBody) {
-		MemberResponse memberInfo = memberService.modifyMemberInfo(request, requestBody);
+	public RsData<MemberResponse> modifyMember(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid MemberUpdateRequest requestBody
+	) {
+		MemberResponse memberInfo = memberService.modifyMemberInfo(userDetails, requestBody);
 		return new RsData<>(
 			"200",
 			"회원정보가 정상적으로 수정되었습니다.",

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -2,6 +2,7 @@ package site.kkokkio.domain.member.controller;
 
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,9 +11,11 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.member.controller.dto.MemberResponse;
 import site.kkokkio.domain.member.controller.dto.MemberSignUpRequest;
+import site.kkokkio.domain.member.controller.dto.MemberUpdateRequest;
 import site.kkokkio.domain.member.service.AuthService;
 import site.kkokkio.domain.member.service.MailService;
 import site.kkokkio.domain.member.service.MemberService;
@@ -52,6 +55,20 @@ public class MemberControllerV1 {
 		return new RsData<>(
 			"200",
 			"마이페이지 조회 성공",
+			memberInfo
+		);
+	}
+
+	// 회원 정보 수정
+	@Operation(summary = "회원수정")
+	@ApiErrorCodeExamples({ErrorCode.MISSING_TOKEN, ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
+		ErrorCode.UNSUPPORTED_TOKEN, ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH})
+	@PatchMapping("/me")
+	public RsData<MemberResponse> modifyMember(HttpServletRequest request, @RequestBody @Valid MemberUpdateRequest requestBody) {
+		MemberResponse memberInfo = memberService.modifyMemberInfo(request, requestBody);
+		return new RsData<>(
+			"200",
+			"회원정보가 정상적으로 수정되었습니다.",
 			memberInfo
 		);
 	}

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/dto/MemberUpdateRequest.java
@@ -11,7 +11,7 @@ public record MemberUpdateRequest(
 		regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$",
 		message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다."
 	)
-	String passwordHash,
+	String password,
 
 	// 닉네임
 	@Size(min = 2, max = 10, message = "닉네임은 2~10자 사이여야 합니다.")

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/dto/MemberUpdateRequest.java
@@ -1,0 +1,21 @@
+package site.kkokkio.domain.member.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MemberUpdateRequest(
+	// 비밀번호
+	@Size(min = 8, max = 20, message = "비밀번호는 8~20자 사이여야 합니다.")
+	@Pattern(
+		regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$",
+		message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다."
+	)
+	String passwordHash,
+
+	// 닉네임
+	@Size(min = 2, max = 10, message = "닉네임은 2~10자 사이여야 합니다.")
+	String nickname
+) {
+
+}

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/dto/PasswordVerificationRequest.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/dto/PasswordVerificationRequest.java
@@ -1,0 +1,10 @@
+package site.kkokkio.domain.member.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class PasswordVerificationRequest {
+	@NotBlank(message = "비밀번호를 입력해주세요.")
+	private String password;
+}

--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -13,8 +13,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
+import site.kkokkio.domain.member.controller.dto.PasswordVerificationRequest;
 import site.kkokkio.domain.member.entity.Member;
 import site.kkokkio.global.exception.ServiceException;
+import site.kkokkio.global.security.CustomUserDetails;
 import site.kkokkio.global.util.JwtUtils;
 
 @Service
@@ -101,5 +103,9 @@ public class AuthService {
 
 		// 쿠키 삭제
 		jwtUtils.clearAuthCookies(response);
+	}
+
+	public boolean checkPassword(PasswordVerificationRequest request, CustomUserDetails userDetails) {
+		return passwordEncoder.matches(request.getPassword(), userDetails.getPassword());
 	}
 }

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -89,6 +89,8 @@ public class SecurityConfig {
 					.requestMatchers(HttpMethod.DELETE, "/api/v1/comments/*").authenticated()			// 댓글 삭제
 					.requestMatchers(HttpMethod.POST, "/api/v1/comments/*/like").authenticated()		// 댓글 좋아요
 					.requestMatchers(HttpMethod.DELETE, "/api/v1/comments/*/like").authenticated()	// 댓글 좋아요 취소
+					.requestMatchers(HttpMethod.POST, "/api/v1/auth/check-password").authenticated()	// 비밀번호 검증
+					.requestMatchers(HttpMethod.PATCH, "/api/v1/member/me").authenticated()			// 회원 정보 수정
 
 					// 그 외 모든 요청 허용
 					.anyRequest().permitAll()

--- a/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
@@ -57,8 +57,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				|| ("POST".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"))      // 댓글 좋아요
 				|| ("DELETE".equals(method) && path.matches("^/api/v1/comments/\\d+/like$"));      // 댓글 좋아요 취소
 
+		boolean isMemberEditEndpoint =
+			("PATCH".equals(method) && path.matches("^/api/v1/member/me$"))
+			|| ("POST".equals(method) && path.matches("^/api/v1/auth/check-password$"));
+
 		// isCommentWriteEndpoint 이면 필터 동작(= false 리턴), 아니면 스킵(= true 리턴)
-		return !isCommentWriteEndpoint;
+		return !isCommentWriteEndpoint && !isMemberEditEndpoint;
 	}
 
 	@Override

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
@@ -216,15 +216,19 @@ class MemberControllerV1Test {
 	@Test
 	@DisplayName("회원 정보 수정 - 인증 토큰 누락으로 실패")
 	void modifyMember_noToken_fail() throws Exception {
-		// given: 토큰 누락 시 CustomAuthException 발생
+		// given
 		given(memberService.modifyMemberInfo(any(HttpServletRequest.class), any(MemberUpdateRequest.class)))
-			.willThrow(new CustomAuthException(
-				CustomAuthException.AuthErrorType.MISSING_TOKEN));
+			.willThrow(new CustomAuthException(CustomAuthException.AuthErrorType.MISSING_TOKEN));
+
+		MemberUpdateRequest request = new MemberUpdateRequest( "ps123123!","after");
+
+		String updateJson = objectMapper.writeValueAsString(request);
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/member/me")
-				.accept(MediaType.APPLICATION_JSON))
-			.andExpect(status().isBadRequest())
+				.contentType(MediaType.APPLICATION_JSON) // 요청 Content-Type 설정 (필요한 경우)
+				.content(updateJson)) // 요청 바디 추가 (필요한 경우)
+			.andExpect(status().isUnauthorized())
 			.andExpect(jsonPath("$.code").value(401))
 			.andExpect(jsonPath("$.message").value("인증 토큰이 없어 인증 실패"));
 	}


### PR DESCRIPTION
## 연관된 이슈

> #188 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 회원정보 수정에 대한 api를 추가하였습니다.
+ 비밀번호 검증 API 추가하였습니다.

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2efcda9a-a289-4c23-b775-3dd0a57694d3)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
API 명세서에 명시된대로
{
	"nickname": "string",
	"passwordHash": "string"
}
를 RequestBody로, 변경 회원은 토큰을 통해 받아오게 설정했습니다.
nickname이나 passwordHash 중 하나만 넣어도 작동되도록 작성했습니다.
