### PR TITLE
Feat/182 setup loki and promtail to grafana

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -41,3 +41,7 @@ redis_data/
 
 # Local 환경의 BaseInit 데이터(GODAOS)
 src/main/java/site/kkokkio/global/init/BaseInitDataLocal.java
+
+# tmp
+logs/
+tmp/

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -1,6 +1,10 @@
 services:
   prometheus:
+    container_name: prometheus
     image: prom/prometheus:latest
+    restart: always
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "9090:9090"
     volumes:
@@ -9,11 +13,40 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
     depends_on:
       - mysql-exporter
+      - loki
+    networks:
+      - monitoring
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    restart: always
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+      - ./tmp/loki:/loki
+    networks:
+      - monitoring
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:latest
+    restart: always
+    volumes:
+      - ./logs:/app/logs
+      - ./promtail-config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
     networks:
       - monitoring
 
   grafana:
+    container_name: grafana
     image: grafana/grafana:latest
+    restart: always
     ports:
       - "3000:3000"
     volumes:
@@ -29,6 +62,7 @@ services:
   mysql-exporter:
     container_name: mysql-exporter
     image: prom/mysqld-exporter:latest
+    restart: always
     ports:
       - "9104:9104"
     command:
@@ -40,7 +74,9 @@ services:
       - monitoring
 
   node-exporter:
+    container_name: node-exporter
     image: prom/node-exporter:latest
+    restart: always
     ports:
       - "9100:9100"
     volumes:
@@ -55,8 +91,8 @@ services:
       - monitoring
 
   db:
-    image: mysql:8.0
     container_name: mysql
+    image: mysql:8.0
     restart: always
     env_file:
       - .env
@@ -74,9 +110,9 @@ services:
     networks:
       - monitoring
 
-  redis: # container name
-    image: redis:alpine
+  redis:
     container_name: redis
+    image: redis:alpine
     restart: always
     ports: # 바인딩할 포트:내부 포트
       - "6379:6379"

--- a/backend/loki-config.yaml
+++ b/backend/loki-config.yaml
@@ -1,0 +1,43 @@
+auth_enabled: false # 인증을 사용하지 않도록 설정
+
+server:
+  http_listen_port: 3100 # Loki 서버가 수신할 HTTP 포트 설정
+
+common:
+  ring:
+    instance_addr: 127.0.0.1 # Loki 인스턴스의 주소
+    kvstore:
+      store: inmemory # 키-값 스토어 설정 (여기서는 메모리 내에서 관리)
+  replication_factor: 1 # 복제 인스턴스 수 (기본값: 1)
+  path_prefix: /tmp/loki # Loki의 기본 경로 설정 (데이터를 저장할 디렉터리 경로)
+
+schema_config:
+  configs:
+    - from: 2020-05-15 # 스키마 버전 시작일 설정 (이 날짜 이후부터 적용)
+      store: tsdb # 저장소 유형 (TSDB 사용)
+      object_store: filesystem # 객체 스토어 유형 (파일 시스템 사용)
+      schema: v13 # 스키마 버전 설정
+      index:
+        prefix: index_ # 인덱스 파일의 접두사 (기본값: 'index_')
+        period: 24h # 인덱스 생성 주기 설정 (24시간마다 새로운 인덱스를 생성)
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+storage_config:
+  filesystem:
+    directory: /tmp/loki/chunks # 파일 시스템에 저장할 로그 청크 디렉터리 경로 설정
+
+limits_config:
+  volume_enabled: true
+  ingestion_rate_mb: 10 # 초당 최대 수집 속도 (기본값: 4MB, 이 값을 10MB로 설정)
+  ingestion_burst_size_mb: 20 # 버스트 모드에서 최대 수집량 (기본값: 6MB, 이 값을 20MB로 설정)
+  per_stream_rate_limit: 5MB # 스트림 당 최대 수집 속도 (기본값: 3MB, 이 값을 5MB로 설정)
+  per_stream_rate_limit_burst: 10MB # 스트림 당 버스트 모드에서 최대 수집량 (기본값: 15MB, 이 값을 10MB로 설정)
+
+# ruler:
+#   alertmanager_url: http://localhost:9093

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -1,12 +1,20 @@
 global:
   scrape_interval: 15s
+  # evaluation_interval: 15s # rule evaluation 주기
 
 scrape_configs:
-  - job_name: 'mysql_exporter'
-    metrics_path: '/metrics'
+  - job_name: "app"
+    metrics_path: "/api/actuator/prometheus"
     static_configs:
-      - targets: ['mysql-exporter:9104']
-  - job_name: 'node_exporter'
+      - targets:
+          - "host.docker.internal:8080"
+        labels:
+          instance: "app"
+  - job_name: "mysql_exporter"
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ["mysql-exporter:9104"]
+  - job_name: "node_exporter"
     scrape_interval: 5s
     static_configs:
-      - targets: ['node-exporter:9100']
+      - targets: ["node-exporter:9100"]

--- a/backend/promtail-config.yml
+++ b/backend/promtail-config.yml
@@ -1,0 +1,22 @@
+server:
+  http_listen_port: 9080 # Promtail 의 HTTP 서버가 요청을 수신할 포트
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: app-logs
+    static_configs:
+      - targets: ["localhost"]
+        labels:
+          job: app
+          __path__: /app/logs/*.log
+
+    pipeline_stages:
+      - multiline:
+          firstline: '^\[ls\] \[' # 로그의 시작을 나타내는 정규식
+          separator: '\] \[le\]' # 멀티라인 로그의 구분자

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -145,8 +145,6 @@ management:
   health:
     circuitbreakers:
       enabled: true
-  server:
-    port: 8081
 
 google:
   trends:

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+    <springProperty name="LOG_LEVEL_ROOT"
+                    source="logging.level.root"
+                    defaultValue="INFO"/>
+
+    <springProfile name="local">
+        <property name="LOG_DIR" value="logs"/>
+
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+                </pattern>
+            </encoder>
+        </appender>
+
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_DIR}/app.log</file>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_DIR}/app-%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
+        </appender>
+
+        <root level="${LOG_LEVEL_ROOT}">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="test">
+        <root level="OFF"/>
+    </springProfile>
+
+    <springProfile name="dev">
+        <property name="LOG_DIR" value="logs"/>
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_DIR}/app.log</file>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_DIR}/app-%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
+        </appender>
+
+        <root level="${LOG_LEVEL_ROOT}">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <property name="LOG_DIR" value="logs"/>
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_DIR}/general.log</file>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_DIR}/general-%d{yyyy-MM-dd}.loghistory</fileNamePattern>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
+        </appender>
+
+        <root level="${LOG_LEVEL_ROOT}">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호
> #182 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

로컬에서 서버 로그가 그라파나에 통합되어 보여질 수 있도록 docker-compose과 관련 logback, config 설정을 추가했습니다.
관련 문서는 팀 블로그 [Prometheus & Loki 기반 모니터링 시스템 구축기](https://www.notion.so/Prometheus-Loki-1f33550b7b55801eae5cec71e59975d7?pvs=4) 에 작성해두었습니다. 
다음 작업으로 terraform에 어떻게 적용할 것인지 경래님과 함께 고민해볼 예정입니다.

## 스크린샷 (선택)
Grafana에서 service(job) 태그 이름을 "app"으로 검색하면 출력됩니다.
<img width="1875" alt="image" src="https://github.com/user-attachments/assets/91ae0dab-6cfd-4193-83ad-87e2ef005e74" />


## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #182