### PR TITLE
Refactor/202 auth refactor

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -68,6 +68,7 @@ public class MemberControllerV1 {
 	@ApiErrorCodeExamples({ErrorCode.MISSING_TOKEN, ErrorCode.TOKEN_EXPIRED, ErrorCode.UNSUPPORTED_TOKEN,
 		ErrorCode.UNSUPPORTED_TOKEN, ErrorCode.MALFORMED_TOKEN, ErrorCode.CREDENTIALS_MISMATCH})
 	@PatchMapping("/me")
+	@IsSelf
 	public RsData<MemberResponse> modifyMember(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestBody @Valid MemberUpdateRequest requestBody

--- a/backend/src/main/java/site/kkokkio/global/auth/annotations/IsActiveMember.java
+++ b/backend/src/main/java/site/kkokkio/global/auth/annotations/IsActiveMember.java
@@ -9,6 +9,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("!hasRole('BLACK')")
+@PreAuthorize("isAuthenticated() && !hasRole('BLACK')")
 public @interface IsActiveMember {
 }

--- a/backend/src/main/java/site/kkokkio/global/auth/annotations/IsAdmin.java
+++ b/backend/src/main/java/site/kkokkio/global/auth/annotations/IsAdmin.java
@@ -9,6 +9,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("isAuthenticated() && hasRole('ADMIN')")
 public @interface IsAdmin {
 }

--- a/backend/src/main/java/site/kkokkio/global/auth/annotations/IsCommentActiveOwner.java
+++ b/backend/src/main/java/site/kkokkio/global/auth/annotations/IsCommentActiveOwner.java
@@ -9,6 +9,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("!hasRole('BLACK') && @authChecker.isOwner('comment', #commentId, authentication)")
+@PreAuthorize("isAuthenticated() && !hasRole('BLACK') && @authChecker.isOwner('comment', #commentId, authentication)")
 public @interface IsCommentActiveOwner {
 }

--- a/backend/src/main/java/site/kkokkio/global/auth/annotations/IsCommentOwner.java
+++ b/backend/src/main/java/site/kkokkio/global/auth/annotations/IsCommentOwner.java
@@ -9,6 +9,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("@authChecker.isOwner('comment', #commentId, authentication)")
+@PreAuthorize("isAuthenticated() && @authChecker.isOwner('comment', #commentId, authentication)")
 public @interface IsCommentOwner {
 }

--- a/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -78,6 +79,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				return;
 			} catch (JwtException e) {
 				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+				return;
+			} catch (UsernameNotFoundException e) {
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "사용자를 찾을 수 없습니다.");
 				return;
 			}
 		}


### PR DESCRIPTION
## 연관된 이슈

> #202 

## 작업 내용

- custom annotation은 붙였는데 security config에서 경로 관리를 하지 않은 경우를 대비해 custom annotation에서도 로그인 여부를 검증하도록 했습니다.
    - SecurityConfig에서의 엔드포인트별 권한 설정: 로그인이 필요한 경로 확인
custom annotation으로 권한 설정: 로그인한 사용자 대상 ROLE 검증
- security config에서 관리하는 경로를 와일드카드를 사용해 정리했습니다.
- JwtAuthenticationFilter에서 발생하는 예외가 500으로 반환되는 문제를 해결했습니다.


## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #202