### PR TITLE
Bug/232 none cookie

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
@@ -50,11 +50,6 @@ public class AuthControllerV1 {
 		// 로그인 서비스 호출
 		MemberLoginResponse loginResponse = authService.login(request.email(), request.passwordHash(), response);
 
-		// // JWT 토큰 쿠키에 설정
-		// jwtUtils.setJwtInCookie(loginResponse.token(), response);
-		// //
-		// jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
-
 		return new RsData<>("200", "로그인 성공", loginResponse);
 	}
 

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/AuthControllerV1.java
@@ -50,10 +50,10 @@ public class AuthControllerV1 {
 		// 로그인 서비스 호출
 		MemberLoginResponse loginResponse = authService.login(request.email(), request.passwordHash(), response);
 
-		// JWT 토큰 쿠키에 설정
-		jwtUtils.setJwtInCookie(loginResponse.token(), response);
-		//
-		jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
+		// // JWT 토큰 쿠키에 설정
+		// jwtUtils.setJwtInCookie(loginResponse.token(), response);
+		// //
+		// jwtUtils.setRefreshTokenInCookie(loginResponse.refreshToken(), response);
 
 		return new RsData<>("200", "로그인 성공", loginResponse);
 	}

--- a/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/controller/MemberControllerV1.java
@@ -32,7 +32,7 @@ import site.kkokkio.global.exception.doc.ErrorCode;
 @Tag(name = "Member API", description = "회원 관련 기능을 제공")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/member")
+@RequestMapping("/api/v1/members")
 public class MemberControllerV1 {
 
 	private final MemberService memberService;

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -105,7 +105,7 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 모든 출처 허용 (운영 환경 배포 시 수정 필요)
-		configuration.setAllowedOriginPatterns(Arrays.asList(
+		configuration.setAllowedOrigins(List.of(
 			// "https://login.aleph.kr", // 임시 프론트 배포 URL1
 			// "https://www.app4.qwas.shop", // 임시 프론트 배포 URL2
 			"https://web.api.deploy.kkokkio.site:3000", // 프론트 API URL

--- a/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
+++ b/backend/src/main/java/site/kkokkio/global/config/SecurityConfig.java
@@ -106,10 +106,10 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		// 모든 출처 허용 (운영 환경 배포 시 수정 필요)
 		configuration.setAllowedOriginPatterns(Arrays.asList(
-			"https://login.aleph.kr", // Todo: 임시 프론트 배포 URL1
-			"https://www.app4.qwas.shop", // Todo: 임시 프론트 배포 URL2
+			// "https://login.aleph.kr", // 임시 프론트 배포 URL1
+			// "https://www.app4.qwas.shop", // 임시 프론트 배포 URL2
 			"https://web.api.deploy.kkokkio.site:3000", // 프론트 API URL
-			"http://localhost:3000", // 로컬용
+			"https://web.kkokkio.site", // 프론트 배포 URL
 			"https://api.deploy.kkokkio.site", // 백엔드 dev API URL
 			"https://api.prd.kkokkio.site"// 백엔드 prod API URL
 		)); // 프론트 사이트 추가

--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -153,7 +153,7 @@ public class JwtUtils {
 	public void setRefreshTokenInCookie(String token, HttpServletResponse response) {
 		ResponseCookie cookie = ResponseCookie.from("refreshToken", token)
 			.httpOnly(true)     // 자바스크립트 접근 차단 (XSS 방지)
-			.path("/api/v1/auth")      // 인증 경로에서만 접근 가능
+			.path("/")      // 인증 경로에서만 접근 가능
 
 			// Todo: 프론트, 백엔드 도메인 일치 후(Strict)적용
 			.sameSite("None")   // 외부 사이트 요청 허용 (CORS 환경 대응)

--- a/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/member/controller/MemberControllerV1Test.java
@@ -95,7 +95,7 @@ class MemberControllerV1Test {
 			""";
 
 		// when & then
-		mockMvc.perform(post("/api/v1/member/signup")
+		mockMvc.perform(post("/api/v1/members/signup")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(signupJson))
 			.andExpect(status().isOk())
@@ -126,7 +126,7 @@ class MemberControllerV1Test {
 			.build();
 
 		// when & then
-		mockMvc.perform(get("/api/v1/member/me")
+		mockMvc.perform(get("/api/v1/members/me")
 				.with(user(new CustomUserDetails(member.getEmail(), member.getRole().toString(), true)))
 				.with(csrf())
 				.contentType(APPLICATION_JSON))
@@ -153,7 +153,7 @@ class MemberControllerV1Test {
 			.build();
 
 		// when & then
-		mockMvc.perform(get("/api/v1/member/me")
+		mockMvc.perform(get("/api/v1/members/me")
 				.with(user(new CustomUserDetails(member.getEmail(), member.getRole().toString(), true)))
 				.with(csrf())
 				.accept(MediaType.APPLICATION_JSON))
@@ -189,7 +189,7 @@ class MemberControllerV1Test {
 		String updateJson = objectMapper.writeValueAsString(request);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/member/me")
+		mockMvc.perform(patch("/api/v1/members/me")
 				.with(user(new CustomUserDetails(
 					member.getEmail(), member.getRole().toString(), member.isEmailVerified())))
 				.with(csrf())
@@ -227,7 +227,7 @@ class MemberControllerV1Test {
 		String updateJson = objectMapper.writeValueAsString(request);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/member/me")
+		mockMvc.perform(patch("/api/v1/members/me")
 				.with(user(new CustomUserDetails(
 					member.getEmail(), member.getRole().toString(), member.isEmailVerified())))
 				.with(csrf())
@@ -254,7 +254,7 @@ class MemberControllerV1Test {
 			.build();
 
 		// when & then
-		mockMvc.perform(delete("/api/v1/member/me")
+		mockMvc.perform(delete("/api/v1/members/me")
 				.with(user(new CustomUserDetails(member.getEmail(), member.getRole().toString(), true)))
 				.with(csrf())
 				.contentType(MediaType.APPLICATION_JSON))
@@ -275,7 +275,7 @@ class MemberControllerV1Test {
 		String json = objectMapper.writeValueAsString(req);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/member/password")
+		mockMvc.perform(patch("/api/v1/members/password")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(json))
 			.andExpect(status().isOk())
@@ -296,7 +296,7 @@ class MemberControllerV1Test {
 		String json = objectMapper.writeValueAsString(req);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/member/password")
+		mockMvc.perform(patch("/api/v1/members/password")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(json))
 			.andExpect(status().isUnauthorized())
@@ -317,7 +317,7 @@ class MemberControllerV1Test {
 		String json = objectMapper.writeValueAsString(req);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/member/password")
+		mockMvc.perform(patch("/api/v1/members/password")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(json))
 			.andExpect(status().isNotFound())


### PR DESCRIPTION
## 연관된 이슈

> ex) #232
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- CORS 배포 주소 허용(프론트 개발 주소)
- Header의 Set-Cookie에 중복되어 저장되는 값 제거
- 기존에 잘못 기입 된 member -> members로 mapping 주소 변경
   - 그에 따른 test코드 수정
- postman을 통한 검증

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- FE  개발자님께서 작성하시 [QA](https://www.notion.so/1f63550b7b558038b6aae586ac1604b5?v=1f63550b7b5580c1833c000c907539ec&pvs=4)에 대한 답변도 달아두었습니다.
closes #232