### PR TITLE
fix: modified to always return success when logout

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
+++ b/backend/src/main/java/site/kkokkio/domain/member/service/AuthService.java
@@ -3,22 +3,27 @@ package site.kkokkio.domain.member.service;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import site.kkokkio.domain.member.controller.dto.MemberLoginResponse;
 import site.kkokkio.domain.member.controller.dto.PasswordVerificationRequest;
 import site.kkokkio.domain.member.entity.Member;
-import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.global.auth.CustomUserDetails;
+import site.kkokkio.global.exception.CustomAuthException;
+import site.kkokkio.global.exception.ServiceException;
 import site.kkokkio.global.util.JwtUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -87,21 +92,23 @@ public class AuthService {
 
 	/** 로그아웃 -> Access Token 블랙리스트 등록 + Refresh Token 삭제 + 쿠키 삭제 */
 	public void logout(HttpServletRequest request, HttpServletResponse response) {
-		String accessToken = jwtUtils.getJwtFromCookies(request)
-			.orElseThrow(() -> new ServiceException("401", "로그인 상태가 아닙니다."));
+		Optional<String> token = jwtUtils.getJwtFromCookies(request);
 
-		// Token의 subject 추출에서 email 추출
-		String email = jwtUtils.getClaims(accessToken).getSubject();
+		if (token.isPresent()) {
+			String accessToken = token.get();
 
-		// Access Token 남은 만료시간 만큼 블랙리스트에 저장
-		long remainingMs = jwtUtils.getExpiration(accessToken).getTime() - System.currentTimeMillis();
-		redisTemplate.opsForValue()
-			.set("blackList:" + accessToken, "logout", Duration.ofMillis(remainingMs));
+			try {
+				String email = jwtUtils.getClaims(accessToken).getSubject();
 
-		// Redis에서 Refresh Token 삭제
-		redisTemplate.delete("refreshToken:" + email);
+				long remainingMs = jwtUtils.getExpiration(accessToken).getTime() - System.currentTimeMillis();
+				redisTemplate.opsForValue()
+					.set("blackList:" + accessToken, "logout", Duration.ofMillis(remainingMs));
 
-		// 쿠키 삭제
+				redisTemplate.delete("refreshToken:" + email);
+			} catch (JwtException | IllegalArgumentException | CustomAuthException e) {
+				log.info(e.toString());
+			}
+		}
 		jwtUtils.clearAuthCookies(response);
 	}
 

--- a/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/site/kkokkio/global/filter/JwtAuthenticationFilter.java
@@ -93,6 +93,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		filterChain.doFilter(request, response);
 	}
 
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return request.getRequestURI().equals("/api/v1/auth/logout");
+	}
+
 	// 쿠키에서 토큰 추출하는 메서드
 	private String extractTokenFromCookie(HttpServletRequest request) {
 		Cookie[] cookies = request.getCookies();


### PR DESCRIPTION
## 연관된 이슈

#264 

## 작업 내용

토큰의 존재/유효 여부와 상관없이 로그아웃 요청이 들어오면 쿠키 삭제 및 200 반환을 하도록 수정했습니다.

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)


closes #264