### PR TITLE
Bug/288 comment fix

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/controller/CommentControllerV1.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,7 +23,6 @@ import site.kkokkio.domain.comment.controller.dto.CommentCreateRequest;
 import site.kkokkio.domain.comment.controller.dto.CommentListResponse;
 import site.kkokkio.domain.comment.dto.CommentDto;
 import site.kkokkio.domain.comment.service.CommentService;
-import site.kkokkio.global.auth.CustomUserDetails;
 import site.kkokkio.global.auth.annotations.IsActiveMember;
 import site.kkokkio.global.auth.annotations.IsCommentActiveOwner;
 import site.kkokkio.global.auth.annotations.IsCommentOwner;
@@ -43,9 +43,10 @@ public class CommentControllerV1 {
 	@GetMapping("/posts/{postId}/comments")
 	public RsData<CommentListResponse> getCommentList(
 		@PathVariable("postId") Long postId,
+		@AuthenticationPrincipal UserDetails userDetails,
 		@ParameterObject @PageableDefault(sort = "likeCount") Pageable pageable
 	) {
-		Page<CommentDto> comments = commentService.getCommentListByPostId(postId, pageable);
+		Page<CommentDto> comments = commentService.getCommentListByPostId(postId, userDetails, pageable);
 
 		CommentListResponse commentListResponse = CommentListResponse.from(comments);
 
@@ -63,7 +64,7 @@ public class CommentControllerV1 {
 	@IsActiveMember
 	public RsData<CommentDto> createComment(
 		@PathVariable("postId") Long postId,
-		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@AuthenticationPrincipal UserDetails userDetails,
 		@Valid @RequestBody CommentCreateRequest request) {
 		CommentDto comment = commentService.createComment(postId, userDetails, request);
 		return new RsData<>(
@@ -116,7 +117,7 @@ public class CommentControllerV1 {
 	@IsActiveMember
 	public RsData<CommentDto> likeComment(
 		@PathVariable("commentId") Long commentId,
-		@AuthenticationPrincipal CustomUserDetails userDetails
+		@AuthenticationPrincipal UserDetails userDetails
 	) {
 		CommentDto comment = commentService.likeComment(commentId, userDetails);
 		return new RsData<>(
@@ -134,7 +135,7 @@ public class CommentControllerV1 {
 	@IsActiveMember
 	public RsData<CommentDto> unlikeComment(
 		@PathVariable("commentId") Long commentId,
-		@AuthenticationPrincipal CustomUserDetails userDetails
+		@AuthenticationPrincipal UserDetails userDetails
 	) {
 		CommentDto comment = commentService.unlikeComment(commentId, userDetails);
 		return new RsData<>(

--- a/backend/src/main/java/site/kkokkio/domain/comment/dto/CommentDto.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/dto/CommentDto.java
@@ -15,6 +15,7 @@ public record CommentDto(
 	@NonNull String nickname,
 	@NonNull String body,
 	@NonNull Integer likeCount,
+	Boolean likedByMe,
 	@NonNull LocalDateTime createdAt
 ) {
 	public static CommentDto from(Comment comment) {
@@ -28,6 +29,23 @@ public record CommentDto(
 			.nickname(nickname)
 			.body(comment.getBody())
 			.likeCount(comment.getLikeCount())
+			.likedByMe(null)
+			.createdAt(comment.getCreatedAt())
+			.build();
+	}
+
+	public static CommentDto from(Comment comment, Boolean likedByMe) {
+		String nickname = comment.getMember().getDeletedAt() != null
+			? "탈퇴한 회원"
+			: comment.getMember().getNickname();
+		return CommentDto.builder()
+			.commentId(comment.getId())
+			.memberId(comment.getMember().getId())
+			.profileUrl("https://i.sstatic.net/l60Hf.png")
+			.nickname(nickname)
+			.body(comment.getBody())
+			.likeCount(comment.getLikeCount())
+			.likedByMe(likedByMe)
 			.createdAt(comment.getCreatedAt())
 			.build();
 	}

--- a/backend/src/main/java/site/kkokkio/domain/comment/repository/CommentLikeRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/repository/CommentLikeRepository.java
@@ -5,10 +5,11 @@ import org.springframework.stereotype.Repository;
 
 import site.kkokkio.domain.comment.entity.Comment;
 import site.kkokkio.domain.comment.entity.CommentLike;
+import site.kkokkio.domain.member.entity.Member;
 
 @Repository
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
-	Boolean existsByComment(Comment comment);
+	Boolean existsByCommentAndMember(Comment comment, Member member);
 
-	void deleteByComment(Comment comment);
+	void deleteByCommentAndMember(Comment comment, Member member);
 }

--- a/backend/src/main/java/site/kkokkio/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/repository/CommentRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import site.kkokkio.domain.comment.entity.Comment;
@@ -17,4 +19,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	@EntityGraph(attributePaths = {"member"})
 	Page<Comment> findAllByPostAndDeletedAtIsNull(Post post, Pageable pageable);
+
+	@Query("SELECT c FROM Comment c JOIN FETCH c.member WHERE c.id = :id")
+	Optional<Comment> findByIdWithMember(@Param("id") Long id);
 }

--- a/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
@@ -41,12 +41,21 @@ public class CommentService {
 	private final CommentReportRepository commentReportRepository;
 	private final MemberService memberService;
 
-	public Page<CommentDto> getCommentListByPostId(Long postId, Pageable pageable) {
+	public Page<CommentDto> getCommentListByPostId(Long postId, UserDetails userDetails, Pageable pageable) {
 		Post post = postRepository.findById(postId)
 			.orElseThrow(() -> new ServiceException("404", "존재하지 않는 포스트입니다."));
 
 		return commentRepository.findAllByPostAndDeletedAtIsNull(post, pageable)
 			.map(CommentDto::from);
+	}
+
+	public Boolean isLikedByMe(UserDetails userDetails, Comment comment) {
+		if (userDetails == null) {
+			return null;
+		}
+
+		Member member = memberService.findByEmail(userDetails.getUsername());
+		return commentLikeRepository.existsByCommentAndMember(comment, member);
 	}
 
 	@Transactional
@@ -96,7 +105,7 @@ public class CommentService {
 			throw new ServiceException("403", "본인 댓글은 좋아요 할 수 없습니다.");
 		}
 
-		if (commentLikeRepository.existsByComment(comment)) {
+		if (commentLikeRepository.existsByCommentAndMember(comment, member)) {
 			throw new ServiceException("400", "이미 좋아요를 누른 댓글입니다.");
 		}
 
@@ -117,12 +126,13 @@ public class CommentService {
 		Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
 			.orElseThrow(() -> new ServiceException("404", "존재하지 않는 댓글입니다."));
 
+		Member member = memberService.findByEmail(userDetails.getUsername());
 		if (comment.getMember().getEmail().equals(userDetails.getUsername())) {
 			throw new ServiceException("403", "본인 댓글은 좋아요 할 수 없습니다.");
 		}
 
-		if (commentLikeRepository.existsByComment(comment)) {
-			commentLikeRepository.deleteByComment(comment);
+		if (commentLikeRepository.existsByCommentAndMember(comment, member)) {
+			commentLikeRepository.deleteByCommentAndMember(comment, member);
 			comment.decreaseLikeCount();
 			commentRepository.save(comment);
 		} else {

--- a/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/site/kkokkio/domain/comment/service/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
 			.orElseThrow(() -> new ServiceException("404", "존재하지 않는 포스트입니다."));
 
 		return commentRepository.findAllByPostAndDeletedAtIsNull(post, pageable)
-			.map(CommentDto::from);
+			.map(comment -> CommentDto.from(comment, isLikedByMe(userDetails, comment)));
 	}
 
 	public Boolean isLikedByMe(UserDetails userDetails, Comment comment) {

--- a/backend/src/main/java/site/kkokkio/global/auth/AuthChecker.java
+++ b/backend/src/main/java/site/kkokkio/global/auth/AuthChecker.java
@@ -26,7 +26,7 @@ public class AuthChecker {
 		UserDetails currentUser = (CustomUserDetails)auth.getPrincipal();
 
 		return switch (resource) {
-			case "comment" -> commentRepository.findById(id)
+			case "comment" -> commentRepository.findByIdWithMember(id)
 				.filter(comment -> comment.getMember().getEmail().equals(currentUser.getUsername()))
 				.isPresent();
 			default -> false;

--- a/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
+++ b/backend/src/test/java/site/kkokkio/domain/comment/controller/CommentControllerV1Test.java
@@ -70,11 +70,12 @@ class CommentControllerV1Test {
 	@Test
 	@DisplayName("댓글 목록 조회 성공")
 	void test1() throws Exception {
-		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "댓글", 0, LocalDateTime.now());
+		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "댓글", 0, null,
+			LocalDateTime.now());
 		Page<CommentDto> page = new PageImpl<>(Collections.singletonList(commentDto),
 			PageRequest.of(0, 10), 1);
 
-		Mockito.when(commentService.getCommentListByPostId(eq(1L), any(Pageable.class)))
+		Mockito.when(commentService.getCommentListByPostId(eq(1L), any(), any(Pageable.class)))
 			.thenReturn(page);
 
 		mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/posts/1/comments")
@@ -90,7 +91,7 @@ class CommentControllerV1Test {
 	void test2() throws Exception {
 		CommentCreateRequest request = new CommentCreateRequest("새 댓글");
 		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "새 댓글", 0,
-			LocalDateTime.now());
+			null, LocalDateTime.now());
 
 		Member member = mock(Member.class);
 		when(member.getRole()).thenReturn(MemberRole.USER);
@@ -141,7 +142,8 @@ class CommentControllerV1Test {
 	void test3() throws Exception {
 		CommentCreateRequest request = new CommentCreateRequest("수정된 댓글");
 		UUID memberId = UUID.randomUUID();
-		CommentDto commentDto = new CommentDto(1L, memberId, "test url", "user", "수정된 댓글", 0, LocalDateTime.now());
+		CommentDto commentDto = new CommentDto(1L, memberId, "test url", "user", "수정된 댓글", 0, null,
+			LocalDateTime.now());
 
 		Member member = mock(Member.class);
 		when(member.getId()).thenReturn(memberId);
@@ -185,7 +187,8 @@ class CommentControllerV1Test {
 	void test3_2() throws Exception {
 		CommentCreateRequest request = new CommentCreateRequest("수정된 댓글");
 		UUID memberId = UUID.randomUUID();
-		CommentDto commentDto = new CommentDto(1L, memberId, "test url", "user", "수정된 댓글", 0, LocalDateTime.now());
+		CommentDto commentDto = new CommentDto(1L, memberId, "test url", "user", "수정된 댓글", 0, null,
+			LocalDateTime.now());
 
 		Member member = mock(Member.class);
 		when(member.getEmail()).thenReturn("other@example.com");
@@ -225,7 +228,8 @@ class CommentControllerV1Test {
 	@Test
 	@DisplayName("댓글 좋아요 성공")
 	void test5() throws Exception {
-		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "댓글", 1, LocalDateTime.now());
+		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "댓글", 1, null,
+			LocalDateTime.now());
 
 		Member member = mock(Member.class);
 		when(member.getRole()).thenReturn(MemberRole.USER);
@@ -245,7 +249,8 @@ class CommentControllerV1Test {
 	@Test
 	@DisplayName("댓글 좋아요 취소 성공")
 	void test6() throws Exception {
-		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "댓글", 0, LocalDateTime.now());
+		CommentDto commentDto = new CommentDto(1L, UUID.randomUUID(), "test url", "user", "댓글", 0, null,
+			LocalDateTime.now());
 
 		Member member = mock(Member.class);
 		when(member.getRole()).thenReturn(MemberRole.USER);

--- a/backend/src/test/java/site/kkokkio/domain/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/site/kkokkio/domain/comment/service/CommentServiceTest.java
@@ -78,7 +78,7 @@ class CommentServiceTest {
 		when(postRepository.findById(1L)).thenReturn(Optional.of(post));
 		when(commentRepository.findAllByPostAndDeletedAtIsNull(eq(post), any())).thenReturn(comments);
 
-		Page<CommentDto> result = commentService.getCommentListByPostId(1L, PageRequest.of(0, 10));
+		Page<CommentDto> result = commentService.getCommentListByPostId(1L, null, PageRequest.of(0, 10));
 
 		assertEquals(1, result.getTotalElements());
 	}
@@ -88,7 +88,8 @@ class CommentServiceTest {
 	void test1_1() {
 		when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
-		assertThrows(ServiceException.class, () -> commentService.getCommentListByPostId(1L, PageRequest.of(0, 10)));
+		assertThrows(ServiceException.class,
+			() -> commentService.getCommentListByPostId(1L, null, PageRequest.of(0, 10)));
 	}
 
 	@Test
@@ -205,7 +206,7 @@ class CommentServiceTest {
 		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
 
 		when(commentRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(comment));
-		when(commentLikeRepository.existsByComment(comment)).thenReturn(false);
+		when(commentLikeRepository.existsByCommentAndMember(comment, member1)).thenReturn(false);
 		when(userDetails.getUsername()).thenReturn(member1.getEmail());
 		when(memberService.findByEmail(any())).thenReturn(member1);
 
@@ -236,7 +237,7 @@ class CommentServiceTest {
 
 		when(commentRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(comment));
 		when(memberService.findByEmail(any())).thenReturn(member);
-		when(commentLikeRepository.existsByComment(comment)).thenReturn(true);
+		when(commentLikeRepository.existsByCommentAndMember(comment, member)).thenReturn(true);
 
 		assertThrows(ServiceException.class, () -> commentService.likeComment(1L, userDetails));
 	}
@@ -255,7 +256,7 @@ class CommentServiceTest {
 		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
 
 		when(commentRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(comment));
-		when(commentLikeRepository.existsByComment(comment)).thenReturn(true);
+		when(commentLikeRepository.existsByCommentAndMember(any(), any())).thenReturn(true);
 
 		CommentDto result = commentService.unlikeComment(1L, member1);
 


### PR DESCRIPTION
## 연관된 이슈

#288 

## 작업 내용

- AuthChecker에서는 comment의 member를 fetch join으로 가져와 lazy loading으로 인한 에러를 피했습니다.
- 댓글 조회 api의 response에 좋아요 확인 플래그를 추가했습니다.
- comment의 존재로만 좋아요 여부를 확인하던 오류를 수정했습니다.

## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>

closes #288