### PR TITLE
Refactor/242 dev upgrade from micro to small 3

### DIFF
--- a/infra/dev/main.tf.backup
+++ b/infra/dev/main.tf.backup
@@ -21,8 +21,7 @@ resource "aws_vpc" "vpc_1" {
   enable_dns_hostnames = true
 
   tags = {
-    # ResourceName = "${var.prefix}-vpc-1"
-    ResourceName = "team04-vpc-1"
+    ResourceName = "${var.prefix}-vpc-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
   }
@@ -131,8 +130,7 @@ resource "aws_route_table_association" "association_4" {
 }
 
 resource "aws_security_group" "sg_1" {
-  # name   = "${var.prefix}-sg-1"
-  name   = "team04-sg-1"
+  name   = "${var.prefix}-sg-1"
   vpc_id = aws_vpc.vpc_1.id
 
   ingress {
@@ -184,34 +182,6 @@ resource "aws_security_group" "sg_1" {
     self      = true
   }
 
-  ingress {
-    from_port = 3000
-    to_port   = 3000
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"] # 필요시 제한 가능
-  }
-
-  ingress {
-    from_port = 9090
-    to_port   = 9090
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 3100
-    to_port   = 3100
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    from_port = 9100
-    to_port   = 9100
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   egress {
     from_port = 0
     to_port   = 0
@@ -220,8 +190,7 @@ resource "aws_security_group" "sg_1" {
   }
 
   tags = {
-    # ResourceName = "${var.prefix}-sg-1"
-    ResourceName = "team04-sg-1"
+    ResourceName = "${var.prefix}-sg-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
     env          = "dev"
@@ -232,8 +201,7 @@ resource "aws_security_group" "sg_1" {
 
 # EC2 역할 생성
 resource "aws_iam_role" "ec2_role_1" {
-  # name = "${var.prefix}-ec2-role-1"
-  name = "team04-ec2-role-1"
+  name = "${var.prefix}-ec2-role-1"
 
   # 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
   assume_role_policy = <<EOF
@@ -250,7 +218,7 @@ resource "aws_iam_role" "ec2_role_1" {
       }
     ]
   }
-EOF
+  EOF
 }
 
 # EC2 역할에 AmazonS3FullAccess 정책을 부착
@@ -267,8 +235,7 @@ resource "aws_iam_role_policy_attachment" "ec2_ssm" {
 
 # IAM 인스턴스 프로파일 생성
 resource "aws_iam_instance_profile" "instance_profile_1" {
-  # name = "${var.prefix}-instance-profile-1"
-  name = "team04-instance-profile-1"
+  name = "${var.prefix}-instance-profile-1"
   role = aws_iam_role.ec2_role_1.name
 }
 
@@ -287,9 +254,6 @@ sudo mkswap /swapfile
 sudo swapon /swapfile
 sudo sh -c 'echo "/swapfile swap swap defaults 0 0" >> /etc/fstab'
 
-캐시 및 목록 업데이트를 먼저 수행하여 설치 안정성 확보
-sudo yum update -y
-
 # 도커 설치 및 실행/활성화
 yum install docker -y
 systemctl enable docker
@@ -301,123 +265,8 @@ yum install -y --allowerasing gnupg2
 # 도플러 CLI 설치
 curl -Ls https://cli.doppler.com/install.sh | sudo DOPPLER_INSTALL_DIR=/usr/local/bin sh
 
-# 프로젝트 디렉토리 및 권한 생성
-for d in tmp/loki logs grafana_data npm_1/volumes/data npm_1/volumes/etc/letsencrypt redis_data db_data mysql_logs; do
-  mkdir -p "/dockerProjects/$d" || { echo "디렉토리 생성 실패: $d"; exit 1; }
-done
-
-chown -R 10001:10001 /dockerProjects/tmp/loki
-chown -R 10001:10001 /dockerProjects/logs
-chown -R 472:472 /dockerProjects/grafana_data
-chown -R 999:999 /dockerProjects/db_data
-chmod -R 755 /dockerProjects
-
 # 도커 네트워크 생성
 docker network create common
-
-# mysqld-exporter 설정 디렉토리 및 .my.cnf 파일 생성
-mkdir -p /dockerProjects/mysql-exporter
-cat <<EOF > /dockerProjects/mysql-exporter/.my.cnf
-[client]
-user=${var.DB_USERNAME} # '%'로 그랜트된 사용자 이름
-password=${var.DB_PASSWORD} # 해당 사용자의 비밀번호 (여기에 직접 변수 사용)
-host=mysql # MySQL 컨테이너의 서비스 이름 사용
-port=3306
-EOF
-
-# .my.cnf 파일 권한 설정 (소유자 외 읽기 금지)
-chmod 644 /dockerProjects/mysql-exporter/.my.cnf
-
-# Loki 설정 파일 작성
-mkdir -p /dockerProjects/tmp/loki /dockerProjects/logs /dockerProjects/grafana_data
-cat <<EOL > /dockerProjects/loki-config.yaml
-auth_enabled: false
-server:
-  http_listen_port: 3100
-common:
-  ring:
-    instance_addr: 127.0.0.1
-    kvstore:
-      store: inmemory
-  replication_factor: 1
-  path_prefix: /tmp/loki
-schema_config:
-  configs:
-    - from: 2020-05-15
-      store: tsdb
-      object_store: filesystem
-      schema: v13
-      index:
-        prefix: index_
-        period: 24h
-query_range:
-  results_cache:
-    cache:
-      embedded_cache:
-        enabled: true
-        max_size_mb: 100
-storage_config:
-  filesystem:
-    directory: /tmp/loki/chunks
-limits_config:
-  volume_enabled: true
-  ingestion_rate_mb: 10
-  ingestion_burst_size_mb: 20
-  per_stream_rate_limit: 5MB
-  per_stream_rate_limit_burst: 10MB
-EOL
-
-sleep 1
-
-# Promtail 설정 파일 작성
-cat <<EOL > /dockerProjects/promtail-config.yml
-server:
-  http_listen_port: 9080
-  grpc_listen_port: 0
-positions:
-  filename: /tmp/positions.yaml
-clients:
-  - url: http://loki:3100/loki/api/v1/push
-scrape_configs:
-  - job_name: app-logs
-    static_configs:
-      - targets: ["localhost"]
-        labels:
-          job: app
-          __path__: /app/logs/*.log
-    pipeline_stages:
-      - multiline:
-          firstline: '^\\[ls\\] \\['
-          separator: '\\] \\[le\\]'
-EOL
-
-sleep 1
-
-# Prometheus 설정 파일 작성
-cat <<EOL > /dockerProjects/prometheus.yml
-global:
-  scrape_interval: 15s
-scrape_configs:
-  - job_name: "app"
-    metrics_path: "/api/actuator/prometheus"
-    honor_labels: true
-    static_configs:
-      - targets:
-          - "app1:8080"
-        labels:
-          instance: "app"
-  - job_name: "node_exporter"
-    scrape_interval: 5s
-    static_configs:
-      - targets: ["node-exporter:9100"]
-# --- MySQL Exporter 메트릭 수집 설정 추가 ---
-  - job_name: "mysql" # MySQL 메트릭을 위한 새로운 Job 이름
-    scrape_interval: 60s # MySQL 메트릭은 보통 1분 간격으로도 충분
-    static_configs:
-      - targets: ["mysql-exporter:9104"] # <--- mysqld_exporter 컨테이너의 서비스 이름과 포트를 지정 (기본 포트는 9104)
-EOL
-
-sleep 1
 
 # nginx-proxy-manager
 docker run -d \
@@ -432,8 +281,6 @@ docker run -d \
   -v /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt \
   jc21/nginx-proxy-manager:latest
 
-sleep 1
-
 # redis 컨테이너 (도커컴포즈 맞춤)
 docker run -d \
   --name redis \
@@ -444,8 +291,6 @@ docker run -d \
   -e TZ=UTC \
   redis:alpine \
   redis-server --notify-keyspace-events Ex --dir /data
-
-sleep 1
 
 # mysql 컨테이너 (도커컴포즈 맞춤)
 docker run -d \
@@ -487,104 +332,7 @@ FLUSH PRIVILEGES;
 echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
 
 # app1 컨테이너 실행 (Doppler 사용)
-# docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
-docker run --restart always \
-  -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} \
-  -d \
-  --name app1 \
-  --network common \
-  -p 8080:8080 \
-  -v /dockerProjects/logs:/app/logs \
-  ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
-
-#Prometheus 실행
-docker run -d \
---name prometheus \
---restart always \
---network common \
--p 9090:9090 \
---add-host=host.docker.internal:host-gateway \
--v /dockerProjects/prometheus.yml:/etc/prometheus/prometheus.yml \
-prom/prometheus:latest \
---config.file=/etc/prometheus/prometheus.yml
-
-# Loki 컨테이너 실행
-docker run -d \
-  --name loki \
-  --restart always \
-  --network common \
-  -p 3100:3100 \
-  -v /dockerProjects/loki-config.yaml:/etc/loki/local-config.yaml \
-  -v /dockerProjects/tmp/loki:/tmp/loki \
-  grafana/loki:latest \
-  -config.file=/etc/loki/local-config.yaml
-
-sleep 1
-
-# Promtail 컨테이너 실행
-docker run -d \
-  --name promtail \
-  --restart always \
-  --network common \
-  -v /dockerProjects/logs:/app/logs \
-  -v /dockerProjects/promtail-config.yml:/etc/promtail/config.yml \
-  grafana/promtail:latest \
-  -config.file=/etc/promtail/config.yml
-
-sleep 1
-
-# Grafana 컨테이너 실행
-docker run -d \
-  --name grafana \
-  --restart always \
-  --network common \
-  -p 3000:3000 \
-  -v /dockerProjects/grafana_data:/var/lib/grafana \
-  -e GF_SECURITY_ADMIN_USER=${var.DB_USERNAME} \
-  -e GF_SECURITY_ADMIN_PASSWORD=${var.DB_PASSWORD} \
-  grafana/grafana:latest
-
-sleep 1
-
-# Node Exporter
-cat <<'EOF' > /usr/local/bin/start_node_exporter.sh
-#!/bin/bash
-docker run -d \
-  --name node-exporter \
-  --restart always \
-  --network common \
-  -p 9100:9100 \
-  -v /proc:/host/proc:ro \
-  -v /sys:/host/sys:ro \
-  -v /:/rootfs:ro \
-  prom/node-exporter:latest \
-  --path.procfs=/host/proc \
-  --path.sysfs=/host/sys \
-  --collector.filesystem.ignored-mount-points='^/(sys|proc|dev|host|etc)($|/)'
-EOF
-
-sleep 1
-
-chmod +x /usr/local/bin/start_node_exporter.sh
-/usr/local/bin/start_node_exporter.sh
-
-# mysql-exporter 컨테이너 실행 명령어 (찾아서 수정해야 하는 명령어)
-# docker run -d \
-#   --name mysql-exporter \
-#   --restart always \
-#   --network common \
-#   -p 9104:9104 \
-#   -e DATA_SOURCE_NAME="${var.MYSQL_USER_2}:${var.PASSWORD_1}@tcp(mysql:3306)/${var.DB_NAME}" \ # <--- 이 라인을 사용하세요! 변수와 인코딩 포함
-#   prom/mysqld-exporter:latest # 사용하는 이미지 이름
-
-docker run -d \
-  --name mysql-exporter \
-  --restart always \
-  --network common \ # MySQL 컨테이너와 같은 네트워크 사용
-  -p 9104:9104 \ # Prometheus가 접근할 포트
-  -v /dockerProjects/mysql-exporter/.my.cnf:/etc/mysql/my.cnf:ro \ # <-- .my.cnf 파일 마운트 (읽기 전용)
-  prom/mysqld-exporter:latest \
-  --config.my-cnf=/etc/mysql/my.cnf
+docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
 
 END_OF_FILE
 }
@@ -621,13 +369,9 @@ resource "aws_instance" "ec2_1" {
   # ami 최신버전이 갱신돼 최신 ami를 받으면 기존 서버가 destroy됨
   # 현재 서버가 destroy되는걸 막기 위해 직접 설정
   # ami = data.aws_ami.latest_amazon_linux.id
-
-  # 초기 개발용 t3.small ami. 이후 사양 추가를 위해 변경
-  # ami = "ami-0eb302fcc77c2f8bd"
-  ami = "ami-05377cf8cfef186c2"
+  ami = "ami-0eb302fcc77c2f8bd"
   # EC2 인스턴스 유형
-  # instance_type = "t3.micro"
-  instance_type = "t3.small"
+  instance_type = "t3.micro"
   # 사용할 서브넷 ID
   subnet_id = aws_subnet.subnet_2.id
   # 적용할 보안 그룹 ID
@@ -640,8 +384,7 @@ resource "aws_instance" "ec2_1" {
 
   # 인스턴스에 태그 설정
   tags = {
-    # ResourceName = "${var.prefix}-ec2-1"
-    ResourceName = "team04-ec2-1"
+    ResourceName = "${var.prefix}-ec2-1"
     Name         = "team04-kkokkio"
     Team         = "devcos5-team04"
     env          = "dev"

--- a/infra/dev/variable.tf
+++ b/infra/dev/variable.tf
@@ -61,6 +61,10 @@ variable "DB_NAME" {
   description = "DB_NAME (Provided via Doppler)"
 }
 
+variable "DB_PORT" {
+  description = "DB_PORT (Provided via Doppler)"
+}
+
 variable "DB_USERNAME" {
   description = "DB_USERNAME (Provided via Doppler)"
 }

--- a/infra/prd/main.tf
+++ b/infra/prd/main.tf
@@ -1,15 +1,15 @@
 terraform {
-  // aws 라이브러리 불러옴
-  required_providers {
-    aws = {
-      source = "hashicorp/aws"
-    }
-  }
+// aws 라이브러리 불러옴
+required_providers {
+aws = {
+source = "hashicorp/aws"
+}
+}
 }
 
 # AWS 설정 시작
 provider "aws" {
-  region = var.region
+region = var.region
 }
 # AWS 설정 끝
 
@@ -18,254 +18,284 @@ provider "aws" {
 ## 변경 ## 기존 개발 환경 VPC를 데이터 소스로 가져옴 - 새로운 VPC 생성 부분을 삭제하고 추가됨
 # 기존 VPC를 CIDR 블록으로 찾습니다. (기존 dev VPC가 10.0.0.0/16임을 가정)
 data "aws_vpc" "existing_vpc" {
-  filter {
-    name = "cidr-block"
-    values = ["10.0.0.0/16"]
-  }
-  filter {
-    name = "tag:Name"
-    values = ["team04-kkokkio"]
-  }
-  filter {
-    name = "tag:Team"
-    values = ["devcos5-team04"]
-  }
+filter {
+name = "cidr-block"
+values = ["10.0.0.0/16"]
+}
+filter {
+name = "tag:Name"
+values = ["team04-kkokkio"]
+}
+filter {
+name = "tag:Team"
+values = ["devcos5-team04"]
+}
 }
 
 resource "aws_subnet" "subnet_1" {
-  vpc_id                  = data.aws_vpc.existing_vpc.id
-  cidr_block              = "10.0.5.0/24"
-  availability_zone       = "${var.region}a"
-  map_public_ip_on_launch = true
+vpc_id                  = data.aws_vpc.existing_vpc.id
+cidr_block              = "10.0.5.0/24"
+availability_zone       = "${var.region}a"
+map_public_ip_on_launch = true
 
-  tags = {
-    ResourceName = "${var.prefix}-subnet-1"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+tags = {
+ResourceName = "${var.prefix}-subnet-1"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 }
 
 resource "aws_subnet" "subnet_2" {
-  vpc_id                  = data.aws_vpc.existing_vpc.id
-  cidr_block              = "10.0.6.0/24"
-  availability_zone       = "${var.region}b"
-  map_public_ip_on_launch = true
+vpc_id                  = data.aws_vpc.existing_vpc.id
+cidr_block              = "10.0.6.0/24"
+availability_zone       = "${var.region}b"
+map_public_ip_on_launch = true
 
-  tags = {
-    ResourceName = "${var.prefix}-subnet-2"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+tags = {
+ResourceName = "${var.prefix}-subnet-2"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 }
 
 resource "aws_subnet" "subnet_3" {
-  vpc_id                  = data.aws_vpc.existing_vpc.id
-  cidr_block              = "10.0.7.0/24"
-  availability_zone       = "${var.region}c"
-  map_public_ip_on_launch = true
+vpc_id                  = data.aws_vpc.existing_vpc.id
+cidr_block              = "10.0.7.0/24"
+availability_zone       = "${var.region}c"
+map_public_ip_on_launch = true
 
-  tags = {
-    ResourceName = "${var.prefix}-subnet-3"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+tags = {
+ResourceName = "${var.prefix}-subnet-3"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 }
 
 resource "aws_subnet" "subnet_4" {
-  vpc_id                  = data.aws_vpc.existing_vpc.id
-  cidr_block              = "10.0.8.0/24"
-  availability_zone       = "${var.region}d"
-  map_public_ip_on_launch = true
+vpc_id                  = data.aws_vpc.existing_vpc.id
+cidr_block              = "10.0.8.0/24"
+availability_zone       = "${var.region}d"
+map_public_ip_on_launch = true
 
-  tags = {
-    ResourceName = "${var.prefix}-subnet-4"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+tags = {
+ResourceName = "${var.prefix}-subnet-4"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 }
 
 # 기존 VPC에 연결된 인터넷 게이트웨이를 데이터 소스로 가져옴
 data "aws_internet_gateway" "existing_igw" {
-  filter {
-    name = "tag:Name"
-    values = ["team04-kkokkio"]
-  }
+filter {
+name = "tag:Name"
+values = ["team04-kkokkio"]
+}
 
-  filter {
-    name = "tag:Team"
-    values = ["devcos5-team04"]
-  }
+filter {
+name = "tag:Team"
+values = ["devcos5-team04"]
+}
 }
 
 resource "aws_route_table" "rt_1" {
-  vpc_id = data.aws_vpc.existing_vpc.id
+vpc_id = data.aws_vpc.existing_vpc.id
 
-  route {
-    cidr_block = "0.0.0.0/0"
-    gateway_id = data.aws_internet_gateway.existing_igw.id
-  }
+route {
+cidr_block = "0.0.0.0/0"
+gateway_id = data.aws_internet_gateway.existing_igw.id
+}
 
-  tags = {
-    ResourceName = "${var.prefix}-rt-1"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+tags = {
+ResourceName = "${var.prefix}-rt-1"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 }
 
 resource "aws_route_table_association" "association_1" {
-  subnet_id      = aws_subnet.subnet_1.id
-  route_table_id = aws_route_table.rt_1.id
+subnet_id      = aws_subnet.subnet_1.id
+route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_route_table_association" "association_2" {
-  subnet_id      = aws_subnet.subnet_2.id
-  route_table_id = aws_route_table.rt_1.id
+subnet_id      = aws_subnet.subnet_2.id
+route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_route_table_association" "association_3" {
-  subnet_id      = aws_subnet.subnet_3.id
-  route_table_id = aws_route_table.rt_1.id
+subnet_id      = aws_subnet.subnet_3.id
+route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_route_table_association" "association_4" {
-  subnet_id      = aws_subnet.subnet_4.id
-  route_table_id = aws_route_table.rt_1.id
+subnet_id      = aws_subnet.subnet_4.id
+route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_security_group" "sg_1" {
-  name   = "${var.prefix}-sg-1"
-  vpc_id = data.aws_vpc.existing_vpc.id
+name   = "${var.prefix}-sg-1"
+vpc_id = data.aws_vpc.existing_vpc.id
 
-  ingress {
-    from_port = 22
-    to_port   = 22
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+ingress {
+from_port = 22
+to_port   = 22
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    from_port = 80
-    to_port   = 80
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+ingress {
+from_port = 80
+to_port   = 80
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    from_port = 81
-    to_port   = 81
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+ingress {
+from_port = 81
+to_port   = 81
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    from_port = 443
-    to_port   = 443
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+ingress {
+from_port = 443
+to_port   = 443
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    from_port = 8080
-    to_port   = 8080
-    protocol  = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+ingress {
+from_port = 8080
+to_port   = 8080
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
 
-  ingress {
-    from_port = 6379
-    to_port   = 6379
-    protocol  = "tcp"
-    self      = true
-  }
+ingress {
+from_port = 6379
+to_port   = 6379
+protocol  = "tcp"
+self      = true
+}
 
-  egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+ingress {
+from_port = 3000
+to_port   = 3000
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"] # 필요시 제한 가능
+}
 
-  tags = {
-    ResourceName = "${var.prefix}-sg-1"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+ingress {
+from_port = 9090
+to_port   = 9090
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
+
+ingress {
+from_port = 3100
+to_port   = 3100
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
+
+ingress {
+from_port = 9100
+to_port   = 9100
+protocol  = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
+}
+
+egress {
+from_port = 0
+to_port   = 0
+protocol  = "-1"
+cidr_blocks = ["0.0.0.0/0"]
+}
+
+tags = {
+ResourceName = "${var.prefix}-sg-1"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 }
 
 # RDS 리소스
 
 # RDS Subnet Group (서브넷 2개 이상 필요) - 새로 생성된 prd 서브넷 3, 4 사용
 resource "aws_db_subnet_group" "rds_subnet_group" {
-  name = "${var.prefix}-rds-subnet-group"
-  subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
+name = "${var.prefix}-rds-subnet-group"
+subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
 
-  tags = {
-    Name = "${var.prefix}-rds-subnet-group"
-    Team = "devcos5-team04"
-    env  = "prd"
-  }
+tags = {
+Name = "${var.prefix}-rds-subnet-group"
+Team = "devcos5-team04"
+env  = "prd"
+}
 }
 
 # RDS 보안 그룹 (EC2에서 접근 가능하도록 설정)
 resource "aws_security_group" "rds_sg" {
-  name   = "${var.prefix}-rds-sg"
-  vpc_id = data.aws_vpc.existing_vpc.id
+name   = "${var.prefix}-rds-sg"
+vpc_id = data.aws_vpc.existing_vpc.id
 
-  ingress {
-    from_port = 3306
-    to_port   = 3306
-    protocol = "tcp"
-    # cidr_blocks = ["10.0.0.0/16"] # EC2와 동일한 VPC 대역
-    security_groups = [aws_security_group.sg_1.id]
-  }
+ingress {
+from_port = 3306
+to_port   = 3306
+protocol = "tcp"
+# cidr_blocks = ["10.0.0.0/16"] # EC2와 동일한 VPC 대역
+security_groups = [aws_security_group.sg_1.id]
+}
 
-  egress {
-    from_port = 0
-    to_port   = 0
-    protocol  = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+# 기존 팀원들의 IP 주소 규칙들을 여기에 추가
 
-  tags = {
-    Name = "${var.prefix}-rds-sg"
-    Team = "devcos5-team04"
-    env  = "prd"
-  }
+egress {
+from_port = 0
+to_port   = 0
+protocol  = "-1"
+cidr_blocks = ["0.0.0.0/0"]
+}
+
+tags = {
+Name = "${var.prefix}-rds-sg"
+Team = "devcos5-team04"
+env  = "prd"
+}
 }
 
 # RDS 인스턴스 생성 (MySQL)
 resource "aws_db_instance" "mysql" {
-  identifier            = "${var.prefix}-mysql"
-  engine                = "mysql"
-  engine_version        = "8.0"
-  instance_class        = "db.t3.micro"
-  allocated_storage     = 20
-  max_allocated_storage = 100
-  storage_type          = "gp2"
+identifier            = "${var.prefix}-mysql"
+engine                = "mysql"
+engine_version        = "8.0"
+instance_class        = "db.t3.micro"
+allocated_storage     = 20
+max_allocated_storage = 100
+storage_type          = "gp2"
 
-  db_name  = var.DB_NAME
-  username = var.DB_USERNAME
-  password = var.DB_PASSWORD
-  port     = 3306
+db_name  = var.DB_NAME
+username = var.DB_USERNAME
+password = var.DB_PASSWORD
+port     = 3306
 
-  vpc_security_group_ids = [aws_security_group.rds_sg.id]
-  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
-  multi_az             = false
-  publicly_accessible  = false
-  skip_final_snapshot  = true
-  deletion_protection  = false
+vpc_security_group_ids = [aws_security_group.rds_sg.id]
+db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+multi_az             = false
+publicly_accessible  = false
+skip_final_snapshot  = true
+deletion_protection  = false
 
-  tags = {
-    Name = "${var.prefix}-mysql"
-    Team = "devcos5-team04"
-    env  = "prd"
-  }
+tags = {
+Name = "${var.prefix}-mysql"
+Team = "devcos5-team04"
+env  = "prd"
+}
 }
 
 
@@ -273,10 +303,10 @@ resource "aws_db_instance" "mysql" {
 
 # EC2 역할 생성
 resource "aws_iam_role" "ec2_role_1" {
-  name = "${var.prefix}-ec2-role-1"
+name = "${var.prefix}-ec2-role-1"
 
-  # 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
-  assume_role_policy = <<EOF
+# 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
+assume_role_policy = <<EOF
   {
     "Version": "2012-10-17",
     "Statement": [
@@ -290,29 +320,178 @@ resource "aws_iam_role" "ec2_role_1" {
       }
     ]
   }
-  EOF
+EOF
 }
 
 # EC2 역할에 AmazonS3FullAccess 정책을 부착
 resource "aws_iam_role_policy_attachment" "s3_full_access" {
-  role       = aws_iam_role.ec2_role_1.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+role       = aws_iam_role.ec2_role_1.name
+policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 # EC2 역할에 AmazonEC2RoleforSSM 정책을 부착
 resource "aws_iam_role_policy_attachment" "ec2_ssm" {
-  role       = aws_iam_role.ec2_role_1.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+role       = aws_iam_role.ec2_role_1.name
+policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
 # IAM 인스턴스 프로파일 생성
 resource "aws_iam_instance_profile" "instance_profile_1" {
-  name = "${var.prefix}-instance-profile-1"
-  role = aws_iam_role.ec2_role_1.name
+name = "${var.prefix}-instance-profile-1"
+role = aws_iam_role.ec2_role_1.name
 }
 
 locals {
-  ec2_user_data_base = <<-END_OF_FILE
+docker_compose_content = <<-EOT
+version: '3.8'
+services:
+  app1:
+    container_name: app1
+    image: ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
+    restart: always
+    environment:
+      - DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN}
+      - DB_HOST=${aws_db_instance.mysql.address} # RDS 엔드포인트를 환경변수로 주입
+      - DB_USERNAME=${var.DB_USERNAME}
+      - DB_PASSWORD=${var.DB_PASSWORD}
+      - DB_NAME=${var.DB_NAME}
+      - DB_PORT=${aws_db_instance.mysql.port}
+    ports:
+      - "8080:8080" # 외부에서 접근해야 할 경우만 포트 매핑 유지
+    volumes:
+      - /dockerProjects/logs:/app/logs
+    networks:
+      - common
+    depends_on:
+      redis:
+        condition: service_started
+
+  redis:
+    container_name: redis
+    image: redis:alpine
+    restart: always
+    ports:
+      - "6379:6379" # 외부에서 접근해야 할 경우만 포트 매핑 유지. app1만 사용한다면 제거 고려.
+    volumes:
+      - /dockerProjects/redis_data:/data
+    command: ["redis-server", "--notify-keyspace-events", "Ex"]
+    networks:
+      - common
+
+  npm_1:
+    container_name: npm_1
+    image: jc21/nginx-proxy-manager:latest
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+      - "81:81"
+    environment:
+      - TZ=UTC
+    volumes:
+      - /dockerProjects/npm_1/volumes/data:/data
+      - /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt
+    networks:
+      - common
+
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:latest
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - /dockerProjects/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    networks:
+      - common
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    restart: always
+    ports:
+      - "3100:3100"
+    volumes:
+      - /dockerProjects/loki-config.yaml:/etc/loki/local-config.yaml
+      - /dockerProjects/tmp/loki:/tmp/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - common
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:latest
+    restart: always
+    volumes:
+      - /dockerProjects/logs:/app/logs:ro
+      - /dockerProjects/promtail-config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
+    networks:
+      - common
+    depends_on:
+      loki:
+        condition: service_started
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    restart: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - /dockerProjects/grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=${var.DB_USERNAME}
+      - GF_SECURITY_ADMIN_PASSWORD=${var.DB_PASSWORD}
+    networks:
+      - common
+    depends_on:
+      prometheus:
+        condition: service_started
+      loki:
+        condition: service_started
+
+  node-exporter:
+    container_name: node-exporter
+    image: prom/node-exporter:latest
+    restart: always
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    networks:
+      - common
+
+  mysql-exporter:
+    container_name: mysql-exporter
+    image: prom/mysqld-exporter:latest
+    restart: always
+    command:
+      - "--mysqld.username=${var.DB_USERNAME}:${var.DB_PASSWORD}"
+      - "--mysqld.address=${aws_db_instance.mysql.address}:${aws_db_instance.mysql.port}"
+    networks:
+      - common
+
+networks:
+  common:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:
+EOT
+}
+
+locals {
+ec2_user_data_base = <<-END_OF_FILE
 #!/bin/bash
 
 # EC2 인스턴스 OS 타임존을 UTC로 설정
@@ -334,109 +513,163 @@ yum install docker -y
 systemctl enable docker
 systemctl start docker
 
+# docker-compose 설치
+curl -L "https://github.com/docker/compose/releases/download/v2.24.5/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+# docker-compose 명령을 /usr/bin에서 바로 실행되도록 심볼릭 링크 생성
+ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
 # gnupg2 설치 (doppler CLI용)
 yum install -y --allowerasing gnupg2
 
 # 도플러 CLI 설치
 curl -Ls https://cli.doppler.com/install.sh | sudo DOPPLER_INSTALL_DIR=/usr/local/bin sh
 
-# 도커 네트워크 생성
-docker network create common
+# 프로젝트 디렉토리 및 권한 생성
+for d in tmp/loki logs grafana_data npm_1/volumes/data npm_1/volumes/etc/letsencrypt redis_data db_data mysql_logs; do
+  mkdir -p "/dockerProjects/$d" || { echo "디렉토리 생성 실패: $d"; exit 1; }
+done
 
-# nginx-proxy-manager
-docker run -d \
-  --name npm_1 \
-  --restart unless-stopped \
-  --network common \
-  -p 80:80 \
-  -p 443:443 \
-  -p 81:81 \
-  -e TZ=UTC \
-  -v /dockerProjects/npm_1/volumes/data:/data \
-  -v /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt \
-  jc21/nginx-proxy-manager:latest
+# mkdir -p "/dockerProjects/mysql-exporter" || { echo "디렉토리 생성 실패: mysql-exporter"; exit 1; }
 
-# redis 컨테이너 (도커컴포즈 맞춤)
-docker run -d \
-  --name redis \
-  --restart always \
-  --network common \
-  -p 6379:6379 \
-  -v /dockerProjects/redis_data:/data \
-  -e TZ=UTC \
-  redis:alpine \
-  redis-server --notify-keyspace-events Ex --dir /data
+chown -R 10001:10001 /dockerProjects/tmp/loki
+chown -R 10001:10001 /dockerProjects/logs
+chown -R 472:472 /dockerProjects/grafana_data
+chmod -R 755 /dockerProjects
 
-# prd 환경에선 mysql 대신 rds 사용
+# Loki 설정 파일 작성
+mkdir -p /dockerProjects/tmp/loki /dockerProjects/logs /dockerProjects/grafana_data
+cat <<EOL > /dockerProjects/loki-config.yaml
+auth_enabled: false
+server:
+  http_listen_port: 3100
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+storage_config:
+  filesystem:
+    directory: /tmp/loki/chunks
+limits_config:
+  volume_enabled: true
+  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 20
+  per_stream_rate_limit: 5MB
+  per_stream_rate_limit_burst: 10MB
+EOL
 
+# Promtail 설정 파일 작성
+cat <<EOL > /dockerProjects/promtail-config.yml
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+positions:
+  filename: /tmp/positions.yaml
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+scrape_configs:
+  - job_name: app-logs
+    static_configs:
+      - targets: ["localhost"]
+        labels:
+          job: app
+          __path__: /app/logs/*.log
+    pipeline_stages:
+      - multiline:
+          firstline: '^\\[ls\\] \\['
+          separator: '\\] \\[le\\]'
+EOL
+
+# Prometheus 설정 파일 작성
+cat <<EOL > /dockerProjects/prometheus.yml
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: "app"
+    metrics_path: "/api/actuator/prometheus"
+    honor_labels: true
+    static_configs:
+      - targets:
+          - "app1:8080"
+        labels:
+          instance: "app"
+  - job_name: "node_exporter"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["node-exporter:9100"]
+# --- MySQL Exporter 메트릭 수집 설정 추가 ---
+  - job_name: "mysql" # MySQL 메트릭을 위한 새로운 Job 이름
+    scrape_interval: 60s # MySQL 메트릭은 보통 1분 간격으로도 충분
+    static_configs:
+      - targets: ["mysql-exporter:9104"] # <--- mysqld_exporter 컨테이너의 서비스 이름과 포트를 지정 (기본 포트는 9104)
+EOL
+
+# GitHub Container Registry 로그인
 echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
 
 # app1 컨테이너 실행 (Doppler 사용)
-docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
+# docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
+
+# Docker Compose 파일 생성 (local.docker_compose_content를 여기에 추가)
+cat <<EOT_DOCKER_COMPOSE > /dockerProjects/docker-compose.yml
+${local.docker_compose_content}
+EOT_DOCKER_COMPOSE
+
+# Docker Compose 실행
+cd /dockerProjects
+docker-compose up -d
 
 END_OF_FILE
 }
-
-#최신 AMI를 찾는 스크립트
-data "aws_ami" "latest_amazon_linux" {
-  most_recent = true
-  owners = ["amazon"]
-
-  filter {
-    name = "name"
-    values = ["al2023-ami-2023.*-x86_64"]
-  }
-
-  filter {
-    name = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 # EC2 인스턴스 생성
 resource "aws_instance" "ec2_1" {
-  # 사용할 AMI ID
-  # ami 최신버전이 갱신돼 최신 ami를 받으면 기존 서버가 destroy됨
-  # 현재 서버가 destroy되는걸 막기 위해 직접 설정
-  # ami = data.aws_ami.latest_amazon_linux.id
-  ami = "ami-0eb302fcc77c2f8bd"
-  # EC2 인스턴스 유형
-  instance_type = "t3.micro"
-  # 사용할 서브넷 ID
-  subnet_id = aws_subnet.subnet_2.id
-  # 적용할 보안 그룹 ID
-  vpc_security_group_ids = [aws_security_group.sg_1.id]
-  # 퍼블릭 IP 연결 설정
-  associate_public_ip_address = true
+# 사용할 AMI ID
+ami = "ami-05377cf8cfef186c2"
+# EC2 인스턴스 유형
+instance_type = "t3.small"
+# 사용할 서브넷 ID
+subnet_id = aws_subnet.subnet_2.id
+# 적용할 보안 그룹 ID
+vpc_security_group_ids = [aws_security_group.sg_1.id]
+# 퍼블릭 IP 연결 설정
+associate_public_ip_address = true
 
-  # 인스턴스에 IAM 역할 연결
-  iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
+# 인스턴스에 IAM 역할 연결
+iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
 
-  # 인스턴스에 태그 설정
-  tags = {
-    ResourceName = "${var.prefix}-ec2-1"
-    Name         = "team04-kkokkio"
-    Team         = "devcos5-team04"
-    env          = "prd"
-  }
+# 인스턴스에 태그 설정
+tags = {
+ResourceName = "${var.prefix}-ec2-1"
+Name         = "team04-kkokkio"
+Team         = "devcos5-team04"
+env          = "prd"
+}
 
-  # 루트 볼륨 설정
-  root_block_device {
-    volume_type = "gp3"
-    volume_size = 12 # 볼륨 크기를 12GB로 설정
-  }
+# 루트 볼륨 설정
+root_block_device {
+volume_type = "gp3"
+volume_size = 12 # 볼륨 크기를 12GB로 설정
+}
 
-  user_data = <<-EOF
+user_data = <<-EOF
 ${local.ec2_user_data_base}
 EOF
 }

--- a/infra/prd/main.tf
+++ b/infra/prd/main.tf
@@ -1,15 +1,15 @@
 terraform {
-// aws 라이브러리 불러옴
-required_providers {
-aws = {
-source = "hashicorp/aws"
-}
-}
+  // aws 라이브러리 불러옴
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }
 
 # AWS 설정 시작
 provider "aws" {
-region = var.region
+  region = var.region
 }
 # AWS 설정 끝
 
@@ -18,284 +18,284 @@ region = var.region
 ## 변경 ## 기존 개발 환경 VPC를 데이터 소스로 가져옴 - 새로운 VPC 생성 부분을 삭제하고 추가됨
 # 기존 VPC를 CIDR 블록으로 찾습니다. (기존 dev VPC가 10.0.0.0/16임을 가정)
 data "aws_vpc" "existing_vpc" {
-filter {
-name = "cidr-block"
-values = ["10.0.0.0/16"]
-}
-filter {
-name = "tag:Name"
-values = ["team04-kkokkio"]
-}
-filter {
-name = "tag:Team"
-values = ["devcos5-team04"]
-}
+  filter {
+    name = "cidr-block"
+    values = ["10.0.0.0/16"]
+  }
+  filter {
+    name = "tag:Name"
+    values = ["team04-kkokkio"]
+  }
+  filter {
+    name = "tag:Team"
+    values = ["devcos5-team04"]
+  }
 }
 
 resource "aws_subnet" "subnet_1" {
-vpc_id                  = data.aws_vpc.existing_vpc.id
-cidr_block              = "10.0.5.0/24"
-availability_zone       = "${var.region}a"
-map_public_ip_on_launch = true
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.5.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = true
 
-tags = {
-ResourceName = "${var.prefix}-subnet-1"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  tags = {
+    ResourceName = "${var.prefix}-subnet-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 }
 
 resource "aws_subnet" "subnet_2" {
-vpc_id                  = data.aws_vpc.existing_vpc.id
-cidr_block              = "10.0.6.0/24"
-availability_zone       = "${var.region}b"
-map_public_ip_on_launch = true
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.6.0/24"
+  availability_zone       = "${var.region}b"
+  map_public_ip_on_launch = true
 
-tags = {
-ResourceName = "${var.prefix}-subnet-2"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  tags = {
+    ResourceName = "${var.prefix}-subnet-2"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 }
 
 resource "aws_subnet" "subnet_3" {
-vpc_id                  = data.aws_vpc.existing_vpc.id
-cidr_block              = "10.0.7.0/24"
-availability_zone       = "${var.region}c"
-map_public_ip_on_launch = true
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.7.0/24"
+  availability_zone       = "${var.region}c"
+  map_public_ip_on_launch = true
 
-tags = {
-ResourceName = "${var.prefix}-subnet-3"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  tags = {
+    ResourceName = "${var.prefix}-subnet-3"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 }
 
 resource "aws_subnet" "subnet_4" {
-vpc_id                  = data.aws_vpc.existing_vpc.id
-cidr_block              = "10.0.8.0/24"
-availability_zone       = "${var.region}d"
-map_public_ip_on_launch = true
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.8.0/24"
+  availability_zone       = "${var.region}d"
+  map_public_ip_on_launch = true
 
-tags = {
-ResourceName = "${var.prefix}-subnet-4"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  tags = {
+    ResourceName = "${var.prefix}-subnet-4"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 }
 
 # 기존 VPC에 연결된 인터넷 게이트웨이를 데이터 소스로 가져옴
 data "aws_internet_gateway" "existing_igw" {
-filter {
-name = "tag:Name"
-values = ["team04-kkokkio"]
-}
+  filter {
+    name = "tag:Name"
+    values = ["team04-kkokkio"]
+  }
 
-filter {
-name = "tag:Team"
-values = ["devcos5-team04"]
-}
+  filter {
+    name = "tag:Team"
+    values = ["devcos5-team04"]
+  }
 }
 
 resource "aws_route_table" "rt_1" {
-vpc_id = data.aws_vpc.existing_vpc.id
+  vpc_id = data.aws_vpc.existing_vpc.id
 
-route {
-cidr_block = "0.0.0.0/0"
-gateway_id = data.aws_internet_gateway.existing_igw.id
-}
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = data.aws_internet_gateway.existing_igw.id
+  }
 
-tags = {
-ResourceName = "${var.prefix}-rt-1"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  tags = {
+    ResourceName = "${var.prefix}-rt-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 }
 
 resource "aws_route_table_association" "association_1" {
-subnet_id      = aws_subnet.subnet_1.id
-route_table_id = aws_route_table.rt_1.id
+  subnet_id      = aws_subnet.subnet_1.id
+  route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_route_table_association" "association_2" {
-subnet_id      = aws_subnet.subnet_2.id
-route_table_id = aws_route_table.rt_1.id
+  subnet_id      = aws_subnet.subnet_2.id
+  route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_route_table_association" "association_3" {
-subnet_id      = aws_subnet.subnet_3.id
-route_table_id = aws_route_table.rt_1.id
+  subnet_id      = aws_subnet.subnet_3.id
+  route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_route_table_association" "association_4" {
-subnet_id      = aws_subnet.subnet_4.id
-route_table_id = aws_route_table.rt_1.id
+  subnet_id      = aws_subnet.subnet_4.id
+  route_table_id = aws_route_table.rt_1.id
 }
 
 resource "aws_security_group" "sg_1" {
-name   = "${var.prefix}-sg-1"
-vpc_id = data.aws_vpc.existing_vpc.id
+  name   = "${var.prefix}-sg-1"
+  vpc_id = data.aws_vpc.existing_vpc.id
 
-ingress {
-from_port = 22
-to_port   = 22
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 80
-to_port   = 80
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 81
-to_port   = 81
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 81
+    to_port   = 81
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 443
-to_port   = 443
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 8080
-to_port   = 8080
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 6379
-to_port   = 6379
-protocol  = "tcp"
-self      = true
-}
+  ingress {
+    from_port = 6379
+    to_port   = 6379
+    protocol  = "tcp"
+    self      = true
+  }
 
-ingress {
-from_port = 3000
-to_port   = 3000
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"] # 필요시 제한 가능
-}
+  ingress {
+    from_port = 3000
+    to_port   = 3000
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # 필요시 제한 가능
+  }
 
-ingress {
-from_port = 9090
-to_port   = 9090
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 9090
+    to_port   = 9090
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 3100
-to_port   = 3100
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 3100
+    to_port   = 3100
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-ingress {
-from_port = 9100
-to_port   = 9100
-protocol  = "tcp"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  ingress {
+    from_port = 9100
+    to_port   = 9100
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-egress {
-from_port = 0
-to_port   = 0
-protocol  = "-1"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-tags = {
-ResourceName = "${var.prefix}-sg-1"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  tags = {
+    ResourceName = "${var.prefix}-sg-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 }
 
 # RDS 리소스
 
 # RDS Subnet Group (서브넷 2개 이상 필요) - 새로 생성된 prd 서브넷 3, 4 사용
 resource "aws_db_subnet_group" "rds_subnet_group" {
-name = "${var.prefix}-rds-subnet-group"
-subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
+  name = "${var.prefix}-rds-subnet-group"
+  subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
 
-tags = {
-Name = "${var.prefix}-rds-subnet-group"
-Team = "devcos5-team04"
-env  = "prd"
-}
+  tags = {
+    Name = "${var.prefix}-rds-subnet-group"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
 }
 
 # RDS 보안 그룹 (EC2에서 접근 가능하도록 설정)
 resource "aws_security_group" "rds_sg" {
-name   = "${var.prefix}-rds-sg"
-vpc_id = data.aws_vpc.existing_vpc.id
+  name   = "${var.prefix}-rds-sg"
+  vpc_id = data.aws_vpc.existing_vpc.id
 
-ingress {
-from_port = 3306
-to_port   = 3306
-protocol = "tcp"
-# cidr_blocks = ["10.0.0.0/16"] # EC2와 동일한 VPC 대역
-security_groups = [aws_security_group.sg_1.id]
-}
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol = "tcp"
+    # cidr_blocks = ["10.0.0.0/16"] # EC2와 동일한 VPC 대역
+    security_groups = [aws_security_group.sg_1.id]
+  }
 
-# 기존 팀원들의 IP 주소 규칙들을 여기에 추가
+  # 기존 팀원들의 IP 주소 규칙들을 여기에 추가
 
-egress {
-from_port = 0
-to_port   = 0
-protocol  = "-1"
-cidr_blocks = ["0.0.0.0/0"]
-}
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
-tags = {
-Name = "${var.prefix}-rds-sg"
-Team = "devcos5-team04"
-env  = "prd"
-}
+  tags = {
+    Name = "${var.prefix}-rds-sg"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
 }
 
 # RDS 인스턴스 생성 (MySQL)
 resource "aws_db_instance" "mysql" {
-identifier            = "${var.prefix}-mysql"
-engine                = "mysql"
-engine_version        = "8.0"
-instance_class        = "db.t3.micro"
-allocated_storage     = 20
-max_allocated_storage = 100
-storage_type          = "gp2"
+  identifier            = "${var.prefix}-mysql"
+  engine                = "mysql"
+  engine_version        = "8.0"
+  instance_class        = "db.t3.micro"
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp2"
 
-db_name  = var.DB_NAME
-username = var.DB_USERNAME
-password = var.DB_PASSWORD
-port     = 3306
+  db_name  = var.DB_NAME
+  username = var.DB_USERNAME
+  password = var.DB_PASSWORD
+  port     = 3306
 
-vpc_security_group_ids = [aws_security_group.rds_sg.id]
-db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
-multi_az             = false
-publicly_accessible  = false
-skip_final_snapshot  = true
-deletion_protection  = false
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+  multi_az             = false
+  publicly_accessible  = false
+  skip_final_snapshot  = true
+  deletion_protection  = false
 
-tags = {
-Name = "${var.prefix}-mysql"
-Team = "devcos5-team04"
-env  = "prd"
-}
+  tags = {
+    Name = "${var.prefix}-mysql"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
 }
 
 
@@ -303,10 +303,10 @@ env  = "prd"
 
 # EC2 역할 생성
 resource "aws_iam_role" "ec2_role_1" {
-name = "${var.prefix}-ec2-role-1"
+  name = "${var.prefix}-ec2-role-1"
 
-# 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
-assume_role_policy = <<EOF
+  # 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
+  assume_role_policy = <<EOF
   {
     "Version": "2012-10-17",
     "Statement": [
@@ -325,24 +325,24 @@ EOF
 
 # EC2 역할에 AmazonS3FullAccess 정책을 부착
 resource "aws_iam_role_policy_attachment" "s3_full_access" {
-role       = aws_iam_role.ec2_role_1.name
-policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 # EC2 역할에 AmazonEC2RoleforSSM 정책을 부착
 resource "aws_iam_role_policy_attachment" "ec2_ssm" {
-role       = aws_iam_role.ec2_role_1.name
-policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
 }
 
 # IAM 인스턴스 프로파일 생성
 resource "aws_iam_instance_profile" "instance_profile_1" {
-name = "${var.prefix}-instance-profile-1"
-role = aws_iam_role.ec2_role_1.name
+  name = "${var.prefix}-instance-profile-1"
+  role = aws_iam_role.ec2_role_1.name
 }
 
 locals {
-docker_compose_content = <<-EOT
+  docker_compose_content = <<-EOT
 version: '3.8'
 services:
   app1:
@@ -491,7 +491,7 @@ EOT
 }
 
 locals {
-ec2_user_data_base = <<-END_OF_FILE
+  ec2_user_data_base = <<-END_OF_FILE
 #!/bin/bash
 
 # EC2 인스턴스 OS 타임존을 UTC로 설정
@@ -594,8 +594,7 @@ scrape_configs:
           __path__: /app/logs/*.log
     pipeline_stages:
       - multiline:
-          firstline: '^\\[ls\\] \\['
-          separator: '\\] \\[le\\]'
+          firstline: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} \['
 EOL
 
 # Prometheus 설정 파일 작성
@@ -641,35 +640,35 @@ END_OF_FILE
 }
 # EC2 인스턴스 생성
 resource "aws_instance" "ec2_1" {
-# 사용할 AMI ID
-ami = "ami-05377cf8cfef186c2"
-# EC2 인스턴스 유형
-instance_type = "t3.small"
-# 사용할 서브넷 ID
-subnet_id = aws_subnet.subnet_2.id
-# 적용할 보안 그룹 ID
-vpc_security_group_ids = [aws_security_group.sg_1.id]
-# 퍼블릭 IP 연결 설정
-associate_public_ip_address = true
+  # 사용할 AMI ID
+  ami = "ami-05377cf8cfef186c2"
+  # EC2 인스턴스 유형
+  instance_type = "t3.small"
+  # 사용할 서브넷 ID
+  subnet_id = aws_subnet.subnet_2.id
+  # 적용할 보안 그룹 ID
+  vpc_security_group_ids = [aws_security_group.sg_1.id]
+  # 퍼블릭 IP 연결 설정
+  associate_public_ip_address = true
 
-# 인스턴스에 IAM 역할 연결
-iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
+  # 인스턴스에 IAM 역할 연결
+  iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
 
-# 인스턴스에 태그 설정
-tags = {
-ResourceName = "${var.prefix}-ec2-1"
-Name         = "team04-kkokkio"
-Team         = "devcos5-team04"
-env          = "prd"
-}
+  # 인스턴스에 태그 설정
+  tags = {
+    ResourceName = "${var.prefix}-ec2-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
 
-# 루트 볼륨 설정
-root_block_device {
-volume_type = "gp3"
-volume_size = 12 # 볼륨 크기를 12GB로 설정
-}
+  # 루트 볼륨 설정
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 12 # 볼륨 크기를 12GB로 설정
+  }
 
-user_data = <<-EOF
+  user_data = <<-EOF
 ${local.ec2_user_data_base}
 EOF
 }

--- a/infra/prd/main.tf.backup
+++ b/infra/prd/main.tf.backup
@@ -1,0 +1,442 @@
+terraform {
+  // aws 라이브러리 불러옴
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+# AWS 설정 시작
+provider "aws" {
+  region = var.region
+}
+# AWS 설정 끝
+
+# VPC 설정 시작
+
+## 변경 ## 기존 개발 환경 VPC를 데이터 소스로 가져옴 - 새로운 VPC 생성 부분을 삭제하고 추가됨
+# 기존 VPC를 CIDR 블록으로 찾습니다. (기존 dev VPC가 10.0.0.0/16임을 가정)
+data "aws_vpc" "existing_vpc" {
+  filter {
+    name = "cidr-block"
+    values = ["10.0.0.0/16"]
+  }
+  filter {
+    name = "tag:Name"
+    values = ["team04-kkokkio"]
+  }
+  filter {
+    name = "tag:Team"
+    values = ["devcos5-team04"]
+  }
+}
+
+resource "aws_subnet" "subnet_1" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.5.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_subnet" "subnet_2" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.6.0/24"
+  availability_zone       = "${var.region}b"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-2"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_subnet" "subnet_3" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.7.0/24"
+  availability_zone       = "${var.region}c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-3"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_subnet" "subnet_4" {
+  vpc_id                  = data.aws_vpc.existing_vpc.id
+  cidr_block              = "10.0.8.0/24"
+  availability_zone       = "${var.region}d"
+  map_public_ip_on_launch = true
+
+  tags = {
+    ResourceName = "${var.prefix}-subnet-4"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+# 기존 VPC에 연결된 인터넷 게이트웨이를 데이터 소스로 가져옴
+data "aws_internet_gateway" "existing_igw" {
+  filter {
+    name = "tag:Name"
+    values = ["team04-kkokkio"]
+  }
+
+  filter {
+    name = "tag:Team"
+    values = ["devcos5-team04"]
+  }
+}
+
+resource "aws_route_table" "rt_1" {
+  vpc_id = data.aws_vpc.existing_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = data.aws_internet_gateway.existing_igw.id
+  }
+
+  tags = {
+    ResourceName = "${var.prefix}-rt-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+resource "aws_route_table_association" "association_1" {
+  subnet_id      = aws_subnet.subnet_1.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_2" {
+  subnet_id      = aws_subnet.subnet_2.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_3" {
+  subnet_id      = aws_subnet.subnet_3.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_route_table_association" "association_4" {
+  subnet_id      = aws_subnet.subnet_4.id
+  route_table_id = aws_route_table.rt_1.id
+}
+
+resource "aws_security_group" "sg_1" {
+  name   = "${var.prefix}-sg-1"
+  vpc_id = data.aws_vpc.existing_vpc.id
+
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 80
+    to_port   = 80
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 81
+    to_port   = 81
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 8080
+    to_port   = 8080
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 6379
+    to_port   = 6379
+    protocol  = "tcp"
+    self      = true
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    ResourceName = "${var.prefix}-sg-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+}
+
+# RDS 리소스
+
+# RDS Subnet Group (서브넷 2개 이상 필요) - 새로 생성된 prd 서브넷 3, 4 사용
+resource "aws_db_subnet_group" "rds_subnet_group" {
+  name = "${var.prefix}-rds-subnet-group"
+  subnet_ids = [aws_subnet.subnet_3.id, aws_subnet.subnet_4.id]
+
+  tags = {
+    Name = "${var.prefix}-rds-subnet-group"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+# RDS 보안 그룹 (EC2에서 접근 가능하도록 설정)
+resource "aws_security_group" "rds_sg" {
+  name   = "${var.prefix}-rds-sg"
+  vpc_id = data.aws_vpc.existing_vpc.id
+
+  ingress {
+    from_port = 3306
+    to_port   = 3306
+    protocol = "tcp"
+    # cidr_blocks = ["10.0.0.0/16"] # EC2와 동일한 VPC 대역
+    security_groups = [aws_security_group.sg_1.id]
+  }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.prefix}-rds-sg"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+# RDS 인스턴스 생성 (MySQL)
+resource "aws_db_instance" "mysql" {
+  identifier            = "${var.prefix}-mysql"
+  engine                = "mysql"
+  engine_version        = "8.0"
+  instance_class        = "db.t3.micro"
+  allocated_storage     = 20
+  max_allocated_storage = 100
+  storage_type          = "gp2"
+
+  db_name  = var.DB_NAME
+  username = var.DB_USERNAME
+  password = var.DB_PASSWORD
+  port     = 3306
+
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name = aws_db_subnet_group.rds_subnet_group.name
+  multi_az             = false
+  publicly_accessible  = false
+  skip_final_snapshot  = true
+  deletion_protection  = false
+
+  tags = {
+    Name = "${var.prefix}-mysql"
+    Team = "devcos5-team04"
+    env  = "prd"
+  }
+}
+
+
+# EC2 설정 시작
+
+# EC2 역할 생성
+resource "aws_iam_role" "ec2_role_1" {
+  name = "${var.prefix}-ec2-role-1"
+
+  # 이 역할에 대한 신뢰 정책 설정. EC2 서비스가 이 역할을 가정할 수 있도록 설정
+  assume_role_policy = <<EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Action": "sts:AssumeRole",
+        "Principal": {
+            "Service": "ec2.amazonaws.com"
+        },
+        "Effect": "Allow"
+      }
+    ]
+  }
+  EOF
+}
+
+# EC2 역할에 AmazonS3FullAccess 정책을 부착
+resource "aws_iam_role_policy_attachment" "s3_full_access" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+
+# EC2 역할에 AmazonEC2RoleforSSM 정책을 부착
+resource "aws_iam_role_policy_attachment" "ec2_ssm" {
+  role       = aws_iam_role.ec2_role_1.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+}
+
+# IAM 인스턴스 프로파일 생성
+resource "aws_iam_instance_profile" "instance_profile_1" {
+  name = "${var.prefix}-instance-profile-1"
+  role = aws_iam_role.ec2_role_1.name
+}
+
+locals {
+  ec2_user_data_base = <<-END_OF_FILE
+#!/bin/bash
+
+# EC2 인스턴스 OS 타임존을 UTC로 설정
+ln -sf /usr/share/zoneinfo/UTC /etc/localtime
+echo "UTC" > /etc/timezone
+
+# 가상 메모리 4GB 설정
+sudo dd if=/dev/zero of=/swapfile bs=128M count=32
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+sudo sh -c 'echo "/swapfile swap swap defaults 0 0" >> /etc/fstab'
+
+캐시 및 목록 업데이트를 먼저 수행하여 설치 안정성 확보
+sudo yum update -y
+
+# 도커 설치 및 실행/활성화
+yum install docker -y
+systemctl enable docker
+systemctl start docker
+
+# gnupg2 설치 (doppler CLI용)
+yum install -y --allowerasing gnupg2
+
+# 도플러 CLI 설치
+curl -Ls https://cli.doppler.com/install.sh | sudo DOPPLER_INSTALL_DIR=/usr/local/bin sh
+
+# 도커 네트워크 생성
+docker network create common
+
+# nginx-proxy-manager
+docker run -d \
+  --name npm_1 \
+  --restart unless-stopped \
+  --network common \
+  -p 80:80 \
+  -p 443:443 \
+  -p 81:81 \
+  -e TZ=UTC \
+  -v /dockerProjects/npm_1/volumes/data:/data \
+  -v /dockerProjects/npm_1/volumes/etc/letsencrypt:/etc/letsencrypt \
+  jc21/nginx-proxy-manager:latest
+
+# redis 컨테이너 (도커컴포즈 맞춤)
+docker run -d \
+  --name redis \
+  --restart always \
+  --network common \
+  -p 6379:6379 \
+  -v /dockerProjects/redis_data:/data \
+  -e TZ=UTC \
+  redis:alpine \
+  redis-server --notify-keyspace-events Ex --dir /data
+
+# prd 환경에선 mysql 대신 rds 사용
+
+echo "${var.GITHUB_ACCESS_TOKEN_1}" | docker login ghcr.io -u ${var.GITHUB_ACCESS_TOKEN_1_OWNER} --password-stdin
+
+# app1 컨테이너 실행 (Doppler 사용)
+docker run --restart always -e DOPPLER_TOKEN=${var.DOPPLER_SERVICE_TOKEN} -d --name app1 --network common -p 8080:8080 ghcr.io/prgrms-web-devcourse-final-project/team04-kkokkio-${var.env}:latest
+
+END_OF_FILE
+}
+
+#최신 AMI를 찾는 스크립트
+data "aws_ami" "latest_amazon_linux" {
+  most_recent = true
+  owners = ["amazon"]
+
+  filter {
+    name = "name"
+    values = ["al2023-ami-2023.*-x86_64"]
+  }
+
+  filter {
+    name = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+# EC2 인스턴스 생성
+resource "aws_instance" "ec2_1" {
+  # 사용할 AMI ID
+  # ami 최신버전이 갱신돼 최신 ami를 받으면 기존 서버가 destroy됨
+  # 현재 서버가 destroy되는걸 막기 위해 직접 설정
+  # ami = data.aws_ami.latest_amazon_linux.id
+  ami = "ami-0eb302fcc77c2f8bd"
+  # EC2 인스턴스 유형
+  instance_type = "t3.micro"
+  # 사용할 서브넷 ID
+  subnet_id = aws_subnet.subnet_2.id
+  # 적용할 보안 그룹 ID
+  vpc_security_group_ids = [aws_security_group.sg_1.id]
+  # 퍼블릭 IP 연결 설정
+  associate_public_ip_address = true
+
+  # 인스턴스에 IAM 역할 연결
+  iam_instance_profile = aws_iam_instance_profile.instance_profile_1.name
+
+  # 인스턴스에 태그 설정
+  tags = {
+    ResourceName = "${var.prefix}-ec2-1"
+    Name         = "team04-kkokkio"
+    Team         = "devcos5-team04"
+    env          = "prd"
+  }
+
+  # 루트 볼륨 설정
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 12 # 볼륨 크기를 12GB로 설정
+  }
+
+  user_data = <<-EOF
+${local.ec2_user_data_base}
+EOF
+}


### PR DESCRIPTION
## 연관된 이슈

> [#292](https://github.com/prgrms-web-devcourse-final-project/WEB4_5_GAEPPADAK_BE/issues/292)

## 작업 내용

> 
- 개발서버 user_data에 도커 컴포즈 추가
-- 개발 서버 mysql 컨테이너에 헬스체크 추가
-- 개발 서버 app1이 mysql 헬스체크를 통과했을 때 작동하도록 변경
-- 개발, 운영 서버 테라폼에 Promtail 설정 파일, Prometheus 설정 파일 최신화 적용
-- 운영 서버 테라폼 코드에 중복되는 부분 제거
-- 개발, 운영 서버 Prometheus, Loki, Node_exporter의 포트를 ec2 내부에서만 접근 가능하도록 수정
-- 개발, 운영 서버의 mysql_exporter에 healthcheck를 추가


## 스크린샷 (선택)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 참고사항

> 테라폼 코드에 설정 파일들이 최신화 되었지만 실제 서버에서는 적용되지 않았습니다.
> 개발 서버 테라폼 코드는 실제로 적용된 운영 서버 테라폼 코드를 참고해 수정했습니다. 
> 실제 개발 서버의 일부 컨테이너는 user_data가 아닌 ssm을 통한 cli 명령어로 만들어졌습니다.

closes #242