### PR TITLE
refactor: 쿠키 만료시간 증가

### DIFF
--- a/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
+++ b/backend/src/main/java/site/kkokkio/global/util/JwtUtils.java
@@ -111,7 +111,9 @@ public class JwtUtils {
 				.build()
 				.parseSignedClaims(token);
 			return true;
-		} catch (ExpiredJwtException | MalformedJwtException | IllegalArgumentException |
+		} catch (ExpiredJwtException e) {
+			throw e;
+		} catch (MalformedJwtException | IllegalArgumentException |
 				 UnsupportedJwtException | SecurityException e) {
 			handleAuthException(e);
 			return false;
@@ -141,7 +143,7 @@ public class JwtUtils {
 
 			// Todo: 프론트, 백엔드 도메인 일치 후(Strict)적용
 			.sameSite("None") // 외부 사이트 요청 차단 (CSRF 방지)
-			.maxAge(Duration.ofMillis(expiration)) // Access Token 만료 시간 : 10분
+			.maxAge(Duration.ofMillis(expiration + 300000)) // Access Token 만료 시간 : 15분
 			.secure(true) // HTTPS 통신 시에만 전송
 			.build();
 


### PR DESCRIPTION
## 연관된 이슈

> ex) #298 
> 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
> 
- accessToken의 만료시간을 확인하기 위해서 쿠키의 지속시간을 5분 증가했습니다.
- jwt accessToken의 만료시간은 기존처럼 10분이고, 쿠키의 지속시간은 15분으로 증가하여 만료된 토큰으로 만료 여부를 확인 할 수 있도록 하였습니다.

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
>
- 임시 방편으로 accessToken 지속시간을 5분 더 증가시켜두었는데 그 안에 클라이언트에서 만료 여부를 확인하는 동작을 하지 않아 리프레쉬 토큰으로 새로운 accessToken을 발급하지 않는다면 기존과 같이 로그아웃처리 '로그인 상태가 아닙니다' 에러 메시지가 나옵니다.
- 좀 더 좋은 해결 방안이 존재한다면 적용해주시면 감사하겠습니다.
closes #298