### PR TITLE
검색 시 게시글이 여전히 보이는 문제 수정

### DIFF
--- a/backend/src/main/java/site/kkokkio/domain/post/repository/PostKeywordRepository.java
+++ b/backend/src/main/java/site/kkokkio/domain/post/repository/PostKeywordRepository.java
@@ -21,12 +21,15 @@ public interface PostKeywordRepository extends JpaRepository<PostKeyword, Long>,
 		JOIN FETCH pk.post p
 		JOIN FETCH pk.keyword k
 		WHERE k.text = :keywordText
+			AND p.deletedAt IS NULL
 		""",
 		countQuery = """
 			SELECT COUNT(pk)
 			FROM PostKeyword pk
 			JOIN pk.keyword k ON pk.keyword.id = k.id
+			JOIN pk.post p ON pk.post.id = p.id
 			WHERE k.text = :keywordText
+				AND p.deletedAt IS NULL
 			""")
 	Page<PostKeyword> findByKeywordTextWithPostAndKeyword(@Param("keywordText") String keywordText, Pageable pageable);
 


### PR DESCRIPTION
## 연관된 이슈

> [#314](https://github.com/prgrms-web-devcourse-final-project/WEB4_5_GAEPPADAK_BE/issues/314)

## 작업 내용

> 검색 시 게시글이 여전히 보이는 문제 수정

## 스크린샷 (선택)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?


closes #314